### PR TITLE
Add MCAP multimodal support to dataset import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ Thumbs.db
 # Agents
 .cursor
 .claude
+.playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository contains skills for computer vision workflows using FiftyOne and
 
 ### FiftyOne Dataset Import (`fiftyone-dataset-import/`)
 
-**When to use:** User wants to import datasets from local files, Hugging Face Hub, or any supported format (COCO, YOLO, VOC, KITTI, etc.), including multimodal grouped datasets.
+**When to use:** User wants to import datasets from local files, Hugging Face Hub, or any supported format (COCO, YOLO, VOC, KITTI, etc.), including multimodal grouped datasets and MCAP robotics/AV sensor recordings.
 
 **Instructions:** Load the skill file at `skills/fiftyone-dataset-import/SKILL.md`
 
@@ -30,6 +30,9 @@ This repository contains skills for computer vision workflows using FiftyOne and
 - COCO, YOLO, VOC, KITTI, CVAT annotations
 - Hugging Face Hub (FiftyOne-formatted, parquet, or raw formats)
 - Multimodal grouped datasets (autonomous driving)
+- MCAP robotics/AV sensor recordings; see `MCAP-TROUBLESHOOTING.md`, `MCAP-AUTHORING.md`, and
+  `MCAP-DATASET-AND-VALIDATION.md` in the skill directory for authoring, converting, and
+  troubleshooting beyond a plain import
 
 ### FiftyOne Dataset Export (`fiftyone-dataset-export/`)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Skills bridge the gap between natural language and FiftyOne's 80+ operators, pro
 
 | Skill | Description | MCP |
 |-------|-------------|-----|
-| 📥 [**Dataset Import**](skills/fiftyone-dataset-import/SKILL.md) | Universal import for all media types, label formats, multimodal groups, and Hugging Face Hub | Yes |
+| 📥 [**Dataset Import**](skills/fiftyone-dataset-import/SKILL.md) | Universal import for all media types, label formats, multimodal groups, MCAP recordings, and Hugging Face Hub | Yes |
 | 📤 [**Dataset Export**](skills/fiftyone-dataset-export/SKILL.md) | Export datasets to COCO, YOLO, VOC, CVAT, CSV, Hugging Face Hub, and more | Yes |
 | 🔍 [**Find Duplicates**](skills/fiftyone-find-duplicates/SKILL.md) | Find and remove duplicate images using brain similarity | Yes |
 | 🤖 [**Dataset Inference**](skills/fiftyone-dataset-inference/SKILL.md) | Run Zoo models for detection, classification, segmentation, embeddings | Yes |

--- a/commands/help.md
+++ b/commands/help.md
@@ -41,7 +41,7 @@ Skills for working with datasets and models:
 
 | Skill | Command | Use When |
 |-------|---------|----------|
-| **Dataset Import** | `/fiftyone:fiftyone-dataset-import` | Importing any dataset (COCO, YOLO, VOC, videos, point clouds, multimodal, Hugging Face Hub) |
+| **Dataset Import** | `/fiftyone:fiftyone-dataset-import` | Importing any dataset (COCO, YOLO, VOC, videos, point clouds, multimodal, MCAP, Hugging Face Hub) |
 | **Dataset Export** | `/fiftyone:fiftyone-dataset-export` | Exporting datasets to standard formats or Hugging Face Hub for training or sharing |
 | **Find Duplicates** | `/fiftyone:fiftyone-find-duplicates` | Removing duplicate or near-duplicate images from datasets |
 | **Dataset Inference** | `/fiftyone:fiftyone-dataset-inference` | Running detection, classification, segmentation, or embeddings on data |

--- a/skills/fiftyone-dataset-import/MCAP-AUTHORING.md
+++ b/skills/fiftyone-dataset-import/MCAP-AUTHORING.md
@@ -1,0 +1,799 @@
+# Authoring, converting, merging, and patching MCAP files
+
+Read this when your job is *producing* `.mcap` content — authoring fresh
+episodes from raw data (Path C), converting ROS bags (Path B), or doing file
+surgery (merge/split/patch) on files from any path. If your `.mcap` files
+already exist and already render correctly, you don't need this file — see
+[SKILL.md](SKILL.md)'s Step 9D instead. If something you authored isn't
+rendering as expected, see [MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md).
+
+## Contents
+
+1. [The three paths, and the minimal authoring skeleton](#1-the-three-paths-and-the-minimal-authoring-skeleton)
+2. [Authoring gaps in foxglove-sdk](#2-authoring-gaps-in-foxglove-sdk)
+3. [Converting ROS bags](#3-converting-ros-bags)
+4. [Merging, splitting, and patching MCAP files](#4-merging-splitting-and-patching-mcap-files)
+5. [Source formats: Zarr, HDF5, PCD, CSV](#5-source-formats-zarr-hdf5-pcd-csv)
+6. [Appendix A: complete ROS 1 two-bag merge](#appendix-a-complete-ros-1-two-bag-merge)
+7. [Appendix B: complete MCAP patch tool](#appendix-b-complete-mcap-patch-tool)
+
+---
+
+## 1. The three paths, and the minimal authoring skeleton
+
+| Path | Starting point | What you do |
+|---|---|---|
+| A | You already have `.mcap` files | Inspect, optionally patch or split, then build the dataset — this is [SKILL.md](SKILL.md)'s Step 9D job, not this file's |
+| B | ROS 1 `.bag` or ROS 2 bags | Convert to one `.mcap` per episode, or hand-merge multiple bags — [§3](#3-converting-ros-bags) below |
+| C | Raw sensor data (image folders, video, point clouds, Zarr, HDF5, CSV telemetry, GPS logs) | Author one `.mcap` per episode with `foxglove-sdk` — this section |
+
+If a recording is split across multiple files (raw plus post-processed, or
+time-chunked), merge them into a single `.mcap` per episode before importing —
+see [§4](#4-merging-splitting-and-patching-mcap-files).
+
+Four structural facts that drive everything else:
+
+- Media type is inferred from the file extension. A sample whose `filepath` ends
+  in `.mcap` makes the dataset `media_type == "multimodal"`. There is no importer
+  class, no config, no media-type flag.
+- One sample equals one episode. Don't split a recording into per-frame samples;
+  the viewer handles playback within an episode. Nothing is unpacked to images on
+  disk, since the viewer streams the MCAP.
+- Media type is fixed per dataset. You cannot mix `.mcap` samples with plain
+  images in one ungrouped dataset. Related non-MCAP media goes in its own dataset.
+- Everything time-varying lives inside the MCAP as a topic. Everything constant
+  for the whole episode lives as a FiftyOne sample field — see
+  [MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#what-goes-on-the-sample-vs-inside-the-mcap).
+
+### Minimal authoring skeleton
+
+The smallest complete program that produces a valid multimodal episode with an
+image stream, a point cloud, a GPS track, and numeric telemetry. Every other
+technique in this skill is a modification of this shape.
+
+```python
+import foxglove
+import numpy as np
+from foxglove.channels import (
+    CompressedImageChannel, PointCloudChannel, LocationFixChannel,
+    FrameTransformChannel,
+)
+from foxglove.messages import (
+    CompressedImage, PointCloud, LocationFix, FrameTransform,
+    PackedElementField, PackedElementFieldNumericType, Timestamp, Vector3,
+    Quaternion, Pose,
+)
+
+def ts(ns: int) -> Timestamp:
+    """Every log_time is nanoseconds since the Unix epoch."""
+    ns = int(ns)
+    return Timestamp(sec=ns // 1_000_000_000, nsec=ns % 1_000_000_000)
+
+f32 = PackedElementFieldNumericType.Float32
+PC_FIELDS = [
+    PackedElementField(name="x", offset=0, type=f32),
+    PackedElementField(name="y", offset=4, type=f32),
+    PackedElementField(name="z", offset=8, type=f32),
+    PackedElementField(name="intensity", offset=12, type=f32),
+]
+
+cam_ch = CompressedImageChannel(
+    topic="/cam_front/image_raw",                     # topic tokens matter, see MCAP-TROUBLESHOOTING.md#73
+    metadata={"mcap.calibration_topic": "/cam_front/calibration"},   # see MCAP-TROUBLESHOOTING.md#72
+)
+lidar_ch = PointCloudChannel(topic="/lidar/points")
+gps_ch = LocationFixChannel(topic="/gps")
+tf_ch = FrameTransformChannel(topic="/tf")
+static_tf_ch = FrameTransformChannel(topic="/tf_static")
+
+with foxglove.open_mcap("episode_0001.mcap", allow_overwrite=True):
+    # Rig extrinsics: log with NO timestamp, or they expire 50 ms into playback.
+    # This is the single most common cause of "Missing transform" — see
+    # MCAP-TROUBLESHOOTING.md#51.
+    static_tf_ch.log(
+        FrameTransform(
+            parent_frame_id="base_link", child_frame_id="lidar",
+            translation=Vector3(x=0.0, y=0.0, z=1.8),
+            rotation=Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+        ),
+        log_time=t0_ns,
+    )
+
+    for t_ns, jpeg_path in camera_frames:            # (capture_ns, path) pairs
+        with open(jpeg_path, "rb") as f:
+            cam_ch.log(
+                CompressedImage(timestamp=ts(t_ns), frame_id="cam_front",
+                                format="jpeg", data=f.read()),
+                log_time=t_ns,
+            )
+
+    for t_ns, xyzi in lidar_sweeps:                  # xyzi: (N, 4) float32
+        if xyzi.shape[0] == 0:
+            continue                                 # never log an empty cloud, see MCAP-TROUBLESHOOTING.md#62
+        lidar_ch.log(
+            PointCloud(
+                timestamp=ts(t_ns), frame_id="lidar",
+                pose=Pose(position=Vector3(), orientation=Quaternion(w=1.0)),
+                point_stride=16, fields=PC_FIELDS,
+                data=np.ascontiguousarray(xyzi, dtype=np.float32).tobytes(),
+            ),
+            log_time=t_ns,
+        )
+        # The MOVING transform (world -> robot) is dynamic and must be re-logged
+        # continuously, because a dynamic sample is only usable within 50 ms of
+        # the playhead (MCAP-TROUBLESHOOTING.md#51).
+        tf_ch.log(
+            FrameTransform(
+                timestamp=ts(t_ns), parent_frame_id="world", child_frame_id="base_link",
+                translation=Vector3(x=px, y=py, z=pz),
+                rotation=Quaternion(x=qx, y=qy, z=qz, w=qw),
+            ),
+            log_time=t_ns,
+        )
+
+    for t_ns, lat, lon, alt in gps_fixes:            # lat/lon in DEGREES, see MCAP-TROUBLESHOOTING.md#85
+        gps_ch.log(
+            LocationFix(timestamp=ts(t_ns), frame_id="gps",
+                        latitude=lat, longitude=lon, altitude=alt),
+            log_time=t_ns,
+        )
+```
+
+Telemetry gets its own channel with a declared schema, which §2 explains:
+
+```python
+import json
+
+def json_channel(topic, fields):
+    """JSON telemetry channel with a declared schema so the Plot tile sees typed
+    fields. `fields` maps name -> "number", "string", or "array"."""
+    kinds = {"number": {"type": "number"},
+             "string": {"type": "string"},
+             "array": {"type": "array", "items": {"type": "number"}}}
+    schema = foxglove.Schema(
+        name=topic.strip("/").replace("/", "_"),
+        encoding="jsonschema",
+        data=json.dumps({"type": "object",
+                         "properties": {n: kinds[k] for n, k in fields.items()}}).encode(),
+    )
+    return foxglove.Channel(topic, message_encoding="json", schema=schema)
+
+telemetry_ch = json_channel("/telemetry", {"speed_mps": "number", "battery_pct": "number"})
+for t_ns, speed, battery in telemetry_rows:
+    telemetry_ch.log({"speed_mps": speed, "battery_pct": battery}, log_time=t_ns)
+```
+
+Rules baked into that skeleton:
+
+- All streams in one episode must share a coherent time base. Episode duration is
+  `max(log_time) - min(log_time)` across all channels.
+- One channel object per topic, and a consistent `frame_id` per sensor.
+- Use real capture timestamps, never wall-clock-at-conversion-time — see
+  [MCAP-TROUBLESHOOTING.md §6](MCAP-TROUBLESHOOTING.md#6-timestamps-and-clock-domains).
+- Newer SDK versions expose message types under `foxglove.messages`;
+  `foxglove.schemas` is a deprecated alias that still works.
+- Overlays/annotations (2D boxes, 3D cuboids, trajectories) are logged the same
+  way — see [MCAP-TROUBLESHOOTING.md §5.9](MCAP-TROUBLESHOOTING.md#59-overlays-and-annotations).
+
+## 2. Authoring gaps in `foxglove-sdk`
+
+Decodable and authorable are different lists. What the viewer can *render* (see
+[MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md)) is not the same as what the
+SDK lets you *write*. Confirmed by inspecting `dir(foxglove.messages)` on 0.26.0:
+
+- **There is no `Imu` message in `foxglove-sdk`.** The `Imu` in the decode table
+  is the ROS schema, decoded when a bag already contains it. When authoring, log
+  IMU as a JSON channel, which still populates the Plot tile through numeric
+  field paths.
+- **A JSON channel needs a declared schema to be plottable.** A channel created
+  without one gets an auto-generated schema, and the Plot tile cannot offer its
+  fields. Use the `json_channel()` helper above.
+- **`Pose.position` needs a `Vector3`, not a `Point3`**, despite the docstring
+  saying "Point denoting position". Passing `Point3` raises
+  `TypeError: 'Point3' object is not an instance of 'Vector3'`. `Point3` is for
+  `Point3InFrame` and standalone point fields.
+- **`JointStates` / `JointState` exists** and is the right schema for per-joint
+  kinematic arrays (position, velocity, effort, acceleration). It is far more
+  compact than flattening 12 joints into a JSON dict, and gets proper binary
+  encoding.
+- **`CompressedImage.format` accepts `png`, not only `jpeg`.** For any image
+  already on disk, prefer re-encoding to `CompressedImage` over `RawImage`, even
+  for single-channel masks. Logging one camera's masks as full-resolution
+  `RawImage` mono8 would have been about 8.3 GB, against about 27 MB for the same
+  content as PNG.
+
+## 3. Converting ROS bags
+
+### 3.1 Straight conversion
+
+```bash
+rosbags-convert --src episode.bag --dst episode_out --dst-storage mcap \
+                --compress zstd --compress-mode storage
+```
+
+- `--dst` is a directory in rosbag2 layout. The actual file is
+  `episode_out/episode_out.mcap`, and that is what the sample points at.
+- Filter channels with `--exclude-topic`, `--include-topic`, `--exclude-msgtype`,
+  `--include-msgtype`. Exclusions win.
+- If a ROS 2 bag already uses mcap storage, the `.mcap` inside can be used
+  directly. Inspect it first — see
+  [MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#summary-read-footer-only-no-message-decode).
+
+Gate conversion on a completeness check so a truncated download can't be
+converted silently:
+
+```bash
+TARGET_BYTES=10906820379
+ACTUAL_BYTES=$(stat -c%s episode.bag)
+if [ "$ACTUAL_BYTES" -lt "$TARGET_BYTES" ]; then
+  echo "incomplete: ${ACTUAL_BYTES} / ${TARGET_BYTES} bytes. Not converting."
+  exit 1
+fi
+```
+
+### 3.2 ROS 1 to ROS 2 CDR by hand: two typestores, always
+
+Needed when a plain conversion can't intercept messages, which is the case for
+topic remapping, frame remapping, transcoding, or merging two bags.
+
+```python
+from rosbags.convert.converter import get_types_from_msg
+from rosbags.typesys import Stores, get_typestore
+
+def build_typestores(*readers):
+    """Two stores, not one. Deserializing raw ROS 1 bytes needs the genuine ROS 1
+    Header (which has `seq`); serializing ROS 2 CDR needs the Header without it.
+    Sharing one store misaligns every message with a nested Header."""
+    src_store = get_typestore(Stores.EMPTY)   # deserialize_ros1
+    dst_store = get_typestore(Stores.EMPTY)   # serialize_cdr / generate_msgdef
+    foxy = get_typestore(Stores.ROS2_FOXY)
+    dst_store.register({"std_msgs/msg/Header": foxy.FIELDDEFS["std_msgs/msg/Header"]})
+
+    camerainfo_def = {"sensor_msgs/msg/CameraInfo": foxy.FIELDDEFS["sensor_msgs/msg/CameraInfo"]}
+    src_store.register(dict(camerainfo_def))          # see MCAP-TROUBLESHOOTING.md#71
+    dst_store.register(dict(camerainfo_def))
+    dst_store.register(                                # output-only type for transcoding
+        {"sensor_msgs/msg/CompressedImage": foxy.FIELDDEFS["sensor_msgs/msg/CompressedImage"]}
+    )
+
+    for reader in readers:
+        for conn in reader.connections:
+            msgtype = resolve_msgtype(conn.msgtype)
+            typs = get_types_from_msg(conn.msgdef, conn.msgtype)
+            if conn.msgtype != msgtype:
+                typs[msgtype] = typs.pop(conn.msgtype)
+            typs.pop("sensor_msgs/msg/CameraInfo", None)
+            src_store.register(dict(typs))
+            typs.pop("std_msgs/msg/Header", None)
+            dst_store.register(typs)
+    return src_store, dst_store
+```
+
+Write schemas with `encoding="ros2msg"` and
+`dst_store.generate_msgdef(msgtype, ros_version=2)`, and channels with
+`message_encoding="cdr"`. That is what the viewer decodes.
+
+### 3.3 Legacy msgtype aliases
+
+A ROS 1 bag can carry a canonical type under an old name. In one real bag, one of
+four `/tf` connections was typed `tf/tfMessage` (12,485 messages) while the other
+three were `tf2_msgs/msg/TFMessage`. They are structurally identical. Unaliased,
+the legacy connection forks into a second channel under the same topic, and every
+`.endswith("TFMessage")` check skips it.
+
+```python
+MSGTYPE_ALIASES = {"tf/tfMessage": "tf2_msgs/msg/TFMessage",
+                   "tf/msg/tfMessage": "tf2_msgs/msg/TFMessage"}
+
+def resolve_msgtype(msgtype):
+    return MSGTYPE_ALIASES.get(msgtype, msgtype)
+```
+
+Key schemas and channels by the resolved msgtype, never the raw one.
+
+## 4. Merging, splitting, and patching MCAP files
+
+### 4.1 Merging N already-written MCAPs
+
+Schema and channel IDs are per-file, so re-register them against the output
+writer, deduped by `(encoding, name)` and `(topic, message_encoding)`. This merges
+files with different encodings, for example a ROS2/CDR conversion and a
+Foxglove/protobuf annotations file, into one episode.
+
+```python
+import heapq
+from pathlib import Path
+from mcap.reader import make_reader
+from mcap.writer import Writer as McapWriter
+
+def merge_mcaps(srcs: list[Path], dst: Path):
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    readers = [make_reader(open(s, "rb")) for s in srcs]
+
+    with open(dst, "wb") as out:
+        writer = McapWriter(out)
+        writer.start()
+        schema_id_map, channel_id_map = {}, {}
+
+        def gen(reader):
+            for schema, channel, message in reader.iter_messages():
+                skey = (schema.encoding, schema.name) if schema else None
+                if skey is not None and skey not in schema_id_map:
+                    schema_id_map[skey] = writer.register_schema(
+                        name=schema.name, encoding=schema.encoding, data=schema.data)
+                ckey = (channel.topic, channel.message_encoding)
+                if ckey not in channel_id_map:
+                    channel_id_map[ckey] = writer.register_channel(
+                        topic=channel.topic, message_encoding=channel.message_encoding,
+                        schema_id=schema_id_map[skey] if skey is not None else 0)
+                yield message.log_time, channel_id_map[ckey], message
+
+        n, first_ts, last_ts = 0, None, None
+        for log_time, channel_id, message in heapq.merge(
+            *[gen(r) for r in readers], key=lambda x: x[0]
+        ):
+            writer.add_message(channel_id, log_time=message.log_time,
+                               data=message.data, publish_time=message.publish_time)
+            first_ts = log_time if first_ts is None else min(first_ts, log_time)
+            last_ts = log_time if last_ts is None else max(last_ts, log_time)
+            n += 1
+        writer.finish()
+    print(f"merged {len(srcs)} files, {n} messages, span {(last_ts - first_ts)/1e9:.2f}s")
+```
+
+### 4.2 Patching an existing MCAP without re-authoring it
+
+The right tool whenever you need to add or fix one topic in a big file. Full
+implementation in [Appendix B](#appendix-b-complete-mcap-patch-tool). The rules
+that make it safe:
+
+1. Copy every schema and channel to a new writer, keeping ID maps.
+2. Copy every message byte-for-byte (`data`, `log_time`, `publish_time`,
+   `sequence`). No decode, no re-encode, no risk.
+3. Insert your new messages at the right `log_time`.
+4. **Update the embedded rosbag2 metadata record.** ROS 2 bags carry a `rosbag2`
+   metadata record holding `topics_with_message_count`. If you add messages and
+   don't update it, `ros2 bag info`-style consumers report stale counts. FiftyOne
+   reads topics from MCAP channel and schema records directly, so this is
+   cosmetic for the viewer but wrong to leave inconsistent.
+5. **Do not fabricate a metadata entry for a Foxglove-schema topic you spliced
+   in.** It isn't a native ROS 2 bag topic, and giving it a
+   `serialization_format: cdr` entry reintroduces exactly the type and format
+   inconsistency that caused an earlier bug.
+
+### 4.3 Splitting one long recording into episodes
+
+Split at semantically meaningful boundaries rather than arbitrary equal chunks.
+One recording published its own operating mode on a string topic, so every real
+mode switch became an episode boundary. Present the candidate segmentations with
+exact timings and message counts and let the user choose.
+
+```python
+from pathlib import Path
+from mcap.reader import make_reader
+from mcap.writer import CompressionType, Writer
+
+def split(src: Path, out_dir: Path, episodes, bag_start_ns: int):
+    """episodes: list of (filename, start_offset_s, end_offset_s)."""
+    out_dir.mkdir(exist_ok=True)
+    with open(src, "rb") as f:
+        reader = make_reader(f)
+        summary = reader.get_summary()
+
+        for name, start_off, end_off in episodes:
+            start_ns = bag_start_ns + int(start_off * 1e9)
+            end_ns = bag_start_ns + int(end_off * 1e9)
+            with open(out_dir / name, "wb") as out_f:
+                writer = Writer(out_f, compression=CompressionType.ZSTD)
+                writer.start()
+                schema_id_map = {
+                    sid: writer.register_schema(name=s.name, encoding=s.encoding, data=s.data)
+                    for sid, s in summary.schemas.items()
+                }
+                channel_id_map = {
+                    cid: writer.register_channel(
+                        topic=c.topic, message_encoding=c.message_encoding,
+                        schema_id=schema_id_map.get(c.schema_id, 0), metadata=c.metadata)
+                    for cid, c in summary.channels.items()
+                }
+                count = 0
+                for _schema, channel, message in reader.iter_messages(
+                    start_time=start_ns, end_time=end_ns
+                ):
+                    writer.add_message(
+                        channel_id=channel_id_map[channel.id], log_time=message.log_time,
+                        data=message.data, publish_time=message.publish_time,
+                        sequence=message.sequence)
+                    count += 1
+                writer.finish()
+            print(f"{name}: {count} msgs, [{start_off:.1f}s, {end_off:.1f}s)")
+```
+
+Always verify conservation. In the split that produced this code, the 5 output
+files summed to exactly 53,219 messages, the source's total.
+
+Keep genuinely odd episodes rather than merging them away, and explain them in a
+sample field. One 12.3 s episode was almost entirely a system-load burst window,
+kept for fidelity to the mode signal with the caveat recorded.
+
+### 4.4 Dropping redundant topics
+
+One merge excludes a single topic: a dense pre-fused XYZRGB `PointCloud2` that
+the robot's own node derived from the depth image, RGB image, and camera info,
+all three of which are kept. It measured 11.18 GB, 57 % of the episode's raw
+content, and was the single largest topic.
+
+The exclusion criterion was *provably derivable from other retained topics*, not
+merely large. Document what is lost.
+
+## 5. Source formats: Zarr, HDF5, PCD, CSV
+
+Gotchas that cost real time before a single message was written.
+
+### 5.1 Zarr
+
+- **Preload every array with `[:]` before indexing it in a loop.** Some arrays
+  are stored as a single chunk covering the whole array, so `arr[i]` inside a
+  Python loop re-decompresses the entire chunk on every access. This alone turned
+  a 1-minute build into a 27-minute hang. Do `x = group["field"][:]` once, then
+  index the numpy array.
+- **A malformed root group can block the whole store.** One mission's root
+  `.zgroup` was 24 bytes of truncated JSON declaring `zarr_format: 3`, failing
+  `zarr.open_group()` on everything. Every individual topic's own
+  `.zgroup`/`.zattrs` (format 2) opened fine standalone, so open topic groups
+  individually rather than the mission root.
+- **Arrays are often padded to a fixed capacity**, for example
+  `(N_scans, 25000, 3)` with a parallel `valid` count. Always slice
+  `points[i, :valid[i], :]`, or you pack thousands of zero rows into the cloud.
+- **Image filename to array row is positional, not by any id column.** A
+  `sequence_id` field can be the original ROS stamp counter, which does not equal
+  the filename index.
+
+### 5.2 HDF5
+
+- **`hdf5plugin` is mandatory and must be imported in every worker process** when
+  arrays use Blosc2 (filter 32026) or Zstd (32015). Without it, `h5py` fails with
+  `can't open directory (/usr/local/lib/plugin)`. With a process pool, the import
+  has to happen inside the worker, not only in the parent.
+- **Index structures beat scanning.** An event-camera stream stores a flat async
+  array plus a `ms_to_idx` table mapping each millisecond to its first event.
+  Using it is the difference between a slice and scanning billions of timestamps.
+- **Rates vary enormously across platforms in one dataset.** Event rate varied
+  more than 13x (1.0k events/ms on one platform, 13.4k on another), so any fixed
+  accumulation window is empty on one and a solid smear on the other. Size the
+  window per sensor to a target fill instead.
+- **Sensor models can differ per platform.** One platform stored raw range images
+  needing beam-intrinsic unprojection from its own embedded metadata, while
+  another stored XYZ directly. Anything touching that sensor needs a
+  per-platform branch.
+
+### 5.3 PCD and point files
+
+- `binary_compressed` PCD reads fine with `pypcd4`.
+- Field lists in real files can exceed the documentation. One radar's PCD carried
+  13 fields against 10 documented, with three undocumented flags. Treat unknown
+  fields as opaque rather than guessing semantics.
+- Organized clouds carry many `(0,0,0)` rows for non-returns. Filter by range —
+  see [MCAP-TROUBLESHOOTING.md §4.2](MCAP-TROUBLESHOOTING.md#42-skip-zero-point-scans-instead-of-logging-an-empty-message).
+
+### 5.4 CSV and text
+
+- A free-text metadata block can precede the real header row. Skip lines until
+  the expected header token appears rather than assuming line 0.
+- Column semantics may not match the spec sheet. One wheel-encoder file had 2
+  columns where the documented message type has 6. Flag it as unconfirmed rather
+  than guessing.
+
+### 5.5 Fitted constants, and how to avoid a wrong negative result
+
+One dataset's only object-level data was a radar track whose scale factors are
+undocumented, so they had to be fitted. The first attempt concluded the geometry
+was unrecoverable. That was wrong, and how it was wrong is the lesson.
+
+Three tests failed for reasons that had nothing to do with the radar: scoring a
+detection by the image pixel it lands on conflates the unknown range scale with
+the unknown mounting height and is degenerate at large ranges; regressing against
+a "lead vehicle" depth kept locking onto parked cars; and one genuinely broken
+field (relative velocity, `r = +0.11 / -0.08 / +0.19` across episodes) was
+allowed to discredit the two good fields alongside it.
+
+What worked was dropping to bird's-eye view and scoring against lidar points that
+project onto vehicle pixels, which removes mounting height from the problem
+entirely and cannot be gamed by pushing objects further away. The range scale then
+showed a sharp optimum at 1/16 m per count: 67.4 % of detections within 3 m of a
+vehicle, against 12.2 % at 0.05 and 19.0 % at 0.08.
+
+The habit worth keeping: the statistics said no, and a rendered frame said yes
+within seconds of looking at it. The visualization script was written only to
+explain a negative result to a human, and it overturned it. **When a correlation
+comes back near zero on data that ought to be structured, draw it before believing
+it.** Keep the failed analyses in the repo so their failure modes stay legible —
+see [MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#process-discipline).
+
+---
+
+## Appendix A: complete ROS 1 two-bag merge
+
+Merges two ROS 1 bags recorded on the same rig into one MCAP episode, applying
+every fix from frame/pose flattening
+([MCAP-TROUBLESHOOTING.md §3](MCAP-TROUBLESHOOTING.md#3-frames-and-transforms)),
+JPEG transcode
+([MCAP-TROUBLESHOOTING.md §5.8](MCAP-TROUBLESHOOTING.md#58-transcoding-raw-images-and-when-not-to)),
+timestamp rebasing
+([MCAP-TROUBLESHOOTING.md §6.6](MCAP-TROUBLESHOOTING.md#66-rebasing-when-merging-sources)),
+and §3.2–3.3 above. Adapt the prefixes, colliding frame names, and excluded
+topics to your data.
+
+```python
+import heapq
+from pathlib import Path
+
+import numpy as np
+from mcap.writer import Writer as McapWriter
+from rosbags.rosbag1 import Reader as Reader1
+
+# helper functions defined earlier in this guide:
+#   build_typestores (3.2), resolve_msgtype (3.3), detect_frame_collision and
+#   remap_frame_ids (MCAP-TROUBLESHOOTING.md#55), flatten_planar_transforms (#56),
+#   repack_pointcloud2 (MCAP-TROUBLESHOOTING.md#63), detect_jpeg_topics and
+#   image_to_compressed (MCAP-TROUBLESHOOTING.md#48)
+
+A_FRAME_REMAP = {"rslidar": "a_rslidar",
+                 "camera_color_optical_frame": "a_camera_color_optical_frame"}
+COLLIDING_FRAMES = set(A_FRAME_REMAP)
+EXCLUDE_TOPICS = set()          # topics provably derivable from retained ones (§4.4)
+
+def register_source(reader, dst_store, writer, prefix, schema_ids, channel_ids, jpeg_topics):
+    conn_to_channel = {}
+    for rconn in reader.connections:
+        if rconn.topic in EXCLUDE_TOPICS:
+            continue
+        msgtype = resolve_msgtype(rconn.msgtype)
+        dst_topic = f"{prefix}{rconn.topic}"
+        # channel type follows the OUTPUT representation, not the source
+        if msgtype == "sensor_msgs/msg/Image" and dst_topic in jpeg_topics:
+            msgtype = "sensor_msgs/msg/CompressedImage"
+        if msgtype not in schema_ids:
+            msgdef, _ = dst_store.generate_msgdef(msgtype, ros_version=2)
+            schema_ids[msgtype] = writer.register_schema(
+                name=msgtype, encoding="ros2msg", data=msgdef.encode())
+        key = (dst_topic, msgtype)      # keyed by RESOLVED msgtype, see §3.3
+        if key not in channel_ids:
+            channel_ids[key] = writer.register_channel(
+                topic=dst_topic, message_encoding="cdr", schema_id=schema_ids[msgtype])
+        conn_to_channel[rconn.id] = channel_ids[key]
+    return conn_to_channel
+
+def merge(bag_a: Path, bag_b: Path, dst: Path):
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    with Reader1(bag_a) as ra, Reader1(bag_b) as rb, open(dst, "wb") as f:
+        src_store, dst_store = build_typestores(ra, rb)
+        b_collides = detect_frame_collision(rb, src_store, COLLIDING_FRAMES)
+        jpeg_topics = (detect_jpeg_topics(ra, src_store, "/a")
+                       | detect_jpeg_topics(rb, src_store, "/b"))
+
+        writer = McapWriter(f)
+        writer.start()
+        schema_ids, channel_ids = {}, {}
+        cm_a = register_source(ra, dst_store, writer, "/a", schema_ids, channel_ids, jpeg_topics)
+        cm_b = register_source(rb, dst_store, writer, "/b", schema_ids, channel_ids, jpeg_topics)
+
+        offset = ra.start_time - rb.start_time          # rebase
+        b_remap = {n: f"b_{n}" for n in COLLIDING_FRAMES} if b_collides else {}
+
+        def gen(reader, connmap, remap, prefix, off=0):
+            for rconn, ts, data in reader.messages():
+                if rconn.topic in EXCLUDE_TOPICS:
+                    continue
+                msgtype = resolve_msgtype(rconn.msgtype)
+                msg = src_store.deserialize_ros1(data, msgtype)
+                if remap:
+                    msg = remap_frame_ids(msg, msgtype, remap)
+                msg = flatten_planar_transforms(msg, msgtype)
+                if msgtype == "sensor_msgs/msg/PointCloud2":
+                    msg = repack_pointcloud2(dst_store, msg)
+                if msgtype == "sensor_msgs/msg/Image" and f"{prefix}{rconn.topic}" in jpeg_topics:
+                    msg = image_to_compressed(dst_store, msg)
+                    msgtype = "sensor_msgs/msg/CompressedImage"
+                yield ts + off, connmap[rconn.id], bytes(dst_store.serialize_cdr(msg, msgtype))
+
+        n, first_ts, last_ts = 0, None, None
+        for ts, channel_id, cdr in heapq.merge(
+            gen(ra, cm_a, A_FRAME_REMAP, "/a"),
+            gen(rb, cm_b, b_remap, "/b", off=offset),
+            key=lambda x: x[0],
+        ):
+            writer.add_message(channel_id, log_time=ts, data=cdr, publish_time=ts)
+            first_ts = ts if first_ts is None else min(first_ts, ts)
+            last_ts = ts if last_ts is None else max(last_ts, ts)
+            n += 1
+
+        # author any static transforms neither bag records, on a topic whose path
+        # segment is exactly "tf_static" (MCAP-TROUBLESHOOTING.md#52)
+        # write_static_tf(writer, dst_store, schema_ids, "/a/tf_static", [...], first_ts)
+
+        writer.finish()
+    print(f"wrote {n} messages, merged duration {(last_ts - first_ts)/1e9:.2f}s -> {dst}")
+```
+
+Static transforms are authored after the message loop, using the same writer:
+
+```python
+def write_static_tf(writer, dst_store, schema_ids, topic, transforms, t_ns):
+    """transforms: list of (parent, child, (x,y,z), (roll,pitch,yaw))."""
+    if "tf2_msgs/msg/TFMessage" not in schema_ids:
+        msgdef, _ = dst_store.generate_msgdef("tf2_msgs/msg/TFMessage", ros_version=2)
+        schema_ids["tf2_msgs/msg/TFMessage"] = writer.register_schema(
+            name="tf2_msgs/msg/TFMessage", encoding="ros2msg", data=msgdef.encode())
+    channel_id = writer.register_channel(
+        topic=topic, message_encoding="cdr", schema_id=schema_ids["tf2_msgs/msg/TFMessage"])
+    data = build_static_tf_bytes(dst_store, transforms, t_ns)
+    writer.add_message(channel_id, log_time=t_ns, data=data, publish_time=t_ns)
+
+def build_static_tf_bytes(dst_store, transforms, t_ns):
+    """transforms: list of (parent, child, (x,y,z), (roll,pitch,yaw)) -> CDR bytes."""
+    from rosbags.typesys import Stores, get_typestore
+    T = get_typestore(Stores.ROS2_FOXY).types
+    sec, nsec = divmod(t_ns, 1_000_000_000)
+    entries = []
+    for parent, child, xyz, rpy in transforms:
+        qx, qy, qz, qw = quat_from_rpy(*rpy)          # see MCAP-TROUBLESHOOTING.md#56
+        entries.append(T["geometry_msgs/msg/TransformStamped"](
+            header=T["std_msgs/msg/Header"](
+                stamp=T["builtin_interfaces/msg/Time"](sec=int(sec), nanosec=int(nsec)),
+                frame_id=parent,
+            ),
+            child_frame_id=child,
+            transform=T["geometry_msgs/msg/Transform"](
+                translation=T["geometry_msgs/msg/Vector3"](x=xyz[0], y=xyz[1], z=xyz[2]),
+                rotation=T["geometry_msgs/msg/Quaternion"](x=qx, y=qy, z=qz, w=qw),
+            ),
+        ))
+    msg = T["tf2_msgs/msg/TFMessage"](transforms=entries)
+    return bytes(dst_store.serialize_cdr(msg, "tf2_msgs/msg/TFMessage"))
+```
+
+Note that a ROS `TransformStamped` always carries a `Header` with a stamp, so ROS
+static transforms cannot be untimestamped the way a Foxglove `FrameTransform`
+can (see [MCAP-TROUBLESHOOTING.md §3.1](MCAP-TROUBLESHOOTING.md#31-the-two-transform-stores-and-the-50-ms-rule)).
+If the resulting episode reports missing transforms, that is the first thing to
+test.
+
+---
+
+## Appendix B: complete MCAP patch tool
+
+Adds messages to an existing MCAP without decoding or re-encoding anything else.
+Use it to promote transforms, splice in a Foxglove-schema topic (see
+[MCAP-TROUBLESHOOTING.md §4.1](MCAP-TROUBLESHOOTING.md#41-large-ros2-cdr-pointcloud2-can-freeze-the-app-foxglovepointcloud-does-not)),
+or fix any single topic in a large file.
+
+```python
+from pathlib import Path
+
+import yaml
+from mcap.reader import make_reader
+from mcap.writer import Writer
+
+def patch_mcap(input_path: Path, output_path: Path, extra_messages,
+               extra_schema=None, extra_channel=None, metadata_deltas=None):
+    """
+    extra_messages: list of (topic, log_time, data, publish_time). Topics must
+        already exist in the source, unless extra_schema/extra_channel are given
+        for a new one.
+    extra_schema/extra_channel: mcap Schema/Channel records for a new topic
+        (for example read out of a mini-MCAP, see MCAP-TROUBLESHOOTING.md#61).
+    metadata_deltas: {topic: n_added} for the embedded rosbag2 metadata record.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_deltas = metadata_deltas or {}
+    n_passthrough = 0
+
+    with open(input_path, "rb") as fin:
+        src = make_reader(fin)
+        summary = src.get_summary()
+        header = src.get_header()
+
+        with open(output_path, "wb") as fout:
+            writer = Writer(fout)
+            writer.start(profile=header.profile, library=header.library)
+
+            schema_id_map = {
+                old_id: writer.register_schema(name=s.name, encoding=s.encoding, data=s.data)
+                for old_id, s in summary.schemas.items()
+            }
+            channel_id_map, topic_to_new_id = {}, {}
+            for old_id, c in summary.channels.items():
+                new_id = writer.register_channel(
+                    topic=c.topic, message_encoding=c.message_encoding,
+                    schema_id=schema_id_map[c.schema_id], metadata=c.metadata or {})
+                channel_id_map[old_id] = new_id
+                topic_to_new_id[c.topic] = new_id
+
+            if extra_schema is not None and extra_channel is not None:
+                new_schema_id = writer.register_schema(
+                    name=extra_schema.name, encoding=extra_schema.encoding,
+                    data=extra_schema.data)
+                topic_to_new_id[extra_channel.topic] = writer.register_channel(
+                    topic=extra_channel.topic,
+                    message_encoding=extra_channel.message_encoding,
+                    schema_id=new_schema_id, metadata=extra_channel.metadata or {})
+
+            # rosbag2 metadata bookkeeping (§4.2 rule 4). Only touch topics that
+            # already exist there; never fabricate an entry for a spliced
+            # Foxglove-schema topic (§4.2 rule 5).
+            for rec in src.iter_metadata():
+                if rec.name != "rosbag2" or "serialized_metadata" not in rec.metadata:
+                    writer.add_metadata(name=rec.name, data=dict(rec.metadata))
+                    continue
+                parsed = yaml.safe_load(rec.metadata["serialized_metadata"])
+                info = parsed.get("rosbag2_bagfile_information", parsed)
+                topics = info.get("topics_with_message_count") or []
+                added = 0
+                for t in topics:
+                    name = t["topic_metadata"]["name"]
+                    if name in metadata_deltas:
+                        t["message_count"] += metadata_deltas[name]
+                        added += metadata_deltas[name]
+                info["message_count"] = int(info.get("message_count", 0)) + added
+                for file_info in info.get("files", []):
+                    file_info["message_count"] = info["message_count"]
+                writer.add_metadata(
+                    name=rec.name,
+                    data={"serialized_metadata": yaml.dump(parsed, default_flow_style=False,
+                                                           sort_keys=False)})
+
+            # interleave the extra messages with the byte-for-byte passthrough
+            pending = sorted(extra_messages, key=lambda m: m[1])
+            idx = 0
+
+            def flush_up_to(t_ns):
+                nonlocal idx
+                while idx < len(pending) and pending[idx][1] <= t_ns:
+                    topic, log_time, data, publish_time = pending[idx]
+                    writer.add_message(channel_id=topic_to_new_id[topic], log_time=log_time,
+                                       data=data, publish_time=publish_time)
+                    idx += 1
+
+            fin.seek(0)
+            for _schema, channel, message in src.iter_messages():
+                flush_up_to(message.log_time)
+                new_id = channel_id_map.get(channel.id)
+                if new_id is None:
+                    continue
+                writer.add_message(channel_id=new_id, log_time=message.log_time,
+                                   data=message.data, publish_time=message.publish_time,
+                                   sequence=message.sequence)
+                n_passthrough += 1
+            while idx < len(pending):
+                flush_up_to(pending[idx][1])
+
+            writer.finish()
+
+    return {"passthrough": n_passthrough, "inserted": len(extra_messages)}
+```
+
+After patching, run `validate_mcap()`
+([MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#a-written-file-is-not-a-good-file))
+and confirm `message_count` equals the source count plus the number of inserted
+messages.
+
+To promote constant transforms from a dynamic topic to the static one, read the
+first observed value of each rigid pair and feed those messages to the patcher:
+
+```python
+from mcap.reader import make_reader
+from mcap_ros2.decoder import DecoderFactory
+
+def find_rigid_transforms(input_path, tf_topic="/tf", base_frame="base_link"):
+    """First-observed TransformStamped for every base_frame->X pair. Verify each
+    is genuinely constant across the episode before using this."""
+    seen = {}
+    with open(input_path, "rb") as f:
+        reader = make_reader(f, decoder_factories=[DecoderFactory()])
+        for _schema, _channel, _msg, ros_msg in reader.iter_decoded_messages(topics=[tf_topic]):
+            for tr in ros_msg.transforms:
+                if tr.header.frame_id == base_frame and tr.child_frame_id not in seen:
+                    seen[tr.child_frame_id] = tr
+    return list(seen.values())
+```

--- a/skills/fiftyone-dataset-import/MCAP-DATASET-AND-VALIDATION.md
+++ b/skills/fiftyone-dataset-import/MCAP-DATASET-AND-VALIDATION.md
@@ -1,0 +1,588 @@
+# Building, validating, and running an MCAP import
+
+Read this once your `.mcap` episodes are authored/converted/patched (see
+[MCAP-AUTHORING.md](MCAP-AUTHORING.md) if not) and you're ready to build the
+FiftyOne dataset and prove it's actually correct. If a tile isn't rendering
+what you expect, see [MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md) instead.
+
+## Contents
+
+1. [Capability flags from schemas, not topic names](#capability-flags-from-schemas-not-topic-names)
+2. [What goes on the sample vs. inside the MCAP](#what-goes-on-the-sample-vs-inside-the-mcap)
+3. [Idempotency, collisions, and stale fields](#idempotency-collisions-and-stale-fields)
+4. [Ambiguous or damaged episodes](#ambiguous-or-damaged-episodes-ship-variants-rather-than-silent-repairs)
+5. [Temporal tags](#temporal-tags)
+6. [Choosing which episodes to import](#choosing-which-episodes-to-import)
+7. [Size, buffering speed, and cost](#size-buffering-speed-and-cost)
+8. [Validation before declaring success](#validation-before-declaring-success)
+9. [Non-negotiables](#non-negotiables)
+10. [Process discipline](#process-discipline)
+11. [Dataset case index](#dataset-case-index)
+12. [The two companion docs to write per dataset](#the-two-companion-docs-to-write-per-dataset)
+
+---
+
+## Capability flags from schemas, not topic names
+
+See [MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md#schema-to-tile-reference)
+for the full schema-to-tile table this is derived from, matching the official
+[Supported schemas](https://docs.voxel51.com/user_guide/multimodal.html#supported-schemas)
+list. A topic's *name* is never a reliable signal for what it renders as.
+
+```python
+import os
+import fiftyone as fo
+from mcap.reader import make_reader
+
+IMAGE_SCHEMAS = {"sensor_msgs/msg/Image", "sensor_msgs/msg/CompressedImage",
+                 "foxglove.RawImage", "foxglove.CompressedImage", "foxglove.CompressedVideo"}
+POINTCLOUD_SCHEMAS = {"sensor_msgs/msg/PointCloud2", "foxglove.PointCloud"}
+# Other content that also renders in the 3D tile, but isn't a point cloud: laser
+# scans, occupancy grids, poses/paths/transforms, markers, and 3D detections.
+OTHER_3D_SCHEMAS = {"sensor_msgs/msg/LaserScan", "foxglove.LaserScan",
+                    "nav_msgs/msg/OccupancyGrid", "foxglove.Grid",
+                    "nav_msgs/msg/Odometry", "nav_msgs/msg/Path",
+                    "geometry_msgs/msg/PoseStamped", "geometry_msgs/msg/PoseArray",
+                    "foxglove.PoseInFrame", "visualization_msgs/msg/Marker",
+                    "visualization_msgs/msg/MarkerArray", "foxglove.SceneUpdate",
+                    "vision_msgs/msg/Detection3DArray"}
+GPS_SCHEMAS = {"sensor_msgs/msg/NavSatFix", "foxglove.LocationFix"}
+# sensor_msgs/msg/Imu isn't in the official supported-schemas list, but the Plot
+# tile decodes any numeric field on any decodable topic, so it plots in practice.
+IMU_SCHEMAS = {"sensor_msgs/msg/Imu"}
+LOG_SCHEMAS = {"rosgraph_msgs/msg/Log", "rcl_interfaces/msg/Log", "foxglove.Log"}
+TRANSFORM_SCHEMAS = {"tf2_msgs/msg/TFMessage", "geometry_msgs/msg/TransformStamped",
+                     "foxglove.FrameTransform", "foxglove.FrameTransforms"}
+KNOWN_SCHEMAS = (IMAGE_SCHEMAS | POINTCLOUD_SCHEMAS | OTHER_3D_SCHEMAS | GPS_SCHEMAS
+                 | IMU_SCHEMAS | LOG_SCHEMAS | TRANSFORM_SCHEMAS)
+
+def mcap_stats(path):
+    with open(path, "rb") as f:
+        summary = make_reader(f).get_summary()
+        topics = sorted({c.topic for c in summary.channels.values()})
+        schemas = sorted({summary.schemas[c.schema_id].name for c in summary.channels.values()
+                          if c.schema_id in summary.schemas})
+        stats = summary.statistics
+        return {
+            "topics": topics,
+            "schemas": schemas,
+            "message_count": stats.message_count,
+            "channel_count": stats.channel_count,
+            "duration_s": round((stats.message_end_time - stats.message_start_time) / 1e9, 1),
+        }
+
+def build_sample(mcap_path, **extra):
+    stats = mcap_stats(mcap_path)
+    schemas = set(stats["schemas"])
+    return fo.Sample(
+        filepath=mcap_path,
+        duration_s=stats["duration_s"],
+        message_count=stats["message_count"],
+        channel_count=stats["channel_count"],
+        topics=stats["topics"],
+        schemas=stats["schemas"],
+        has_image=bool(IMAGE_SCHEMAS & schemas),
+        has_pointcloud=bool(POINTCLOUD_SCHEMAS & schemas),
+        has_3d_content=bool((POINTCLOUD_SCHEMAS | OTHER_3D_SCHEMAS | TRANSFORM_SCHEMAS) & schemas),
+        has_gps=bool(GPS_SCHEMAS & schemas),
+        has_imu=bool(IMU_SCHEMAS & schemas),
+        has_logs=bool(LOG_SCHEMAS & schemas),
+        has_transforms=bool(TRANSFORM_SCHEMAS & schemas),
+        has_unrecognized_schema=bool(schemas - KNOWN_SCHEMAS),
+        **extra,
+    )
+
+dataset = fo.Dataset("my-dataset-multimodal", persistent=True)
+dataset.add_samples([build_sample(p, scenario="urban") for p in episode_paths])
+assert dataset.media_type == "multimodal", dataset.media_type
+```
+
+Add dataset-specific flags wherever they let you filter the grid, for example
+`has_food_cam`, `has_2d_lidar_raw`, `has_ir`, `has_audio`, `has_gt_pose`,
+`has_events`, `has_zed_dropout`.
+
+Derive them from the file, not from the dataset's own metadata table. In one
+import, an episode's CSV claimed a second camera was present but the bag had no
+such topic at all. Keep the source column as a secondary cross-check field if it
+is useful.
+
+## What goes on the sample vs. inside the MCAP
+
+- **Sample fields:** constants for the whole episode (ego velocity, distance to
+  object, ambient temperature, scenario, operator, session, route length, GPS
+  quality, degraded flags, ground-truth file paths). These are the only way to
+  filter episodes in the grid without Enterprise MCAP indexing.
+- **MCAP topics:** anything time-varying (telemetry, poses, per-frame labels).
+- **`dataset.info`:** things shared by every episode, such as calibration
+  matrices, source URL, license, paper reference, and excluded-sequence notes.
+
+```python
+dataset.info = {
+    "source": "https://example.org/dataset",
+    "license": "CC BY 4.0",
+    "calibration": {"T_cam_lidar": {"R": R.tolist(), "t": t.tolist()}},
+    "excluded_sequences": {"LF-03-D": "corrupted by a ~520ms backward clock step"},
+}
+dataset.save()
+```
+
+## Idempotency, collisions, and stale fields
+
+```python
+# refuse: safest for a one-shot import
+if NAME in fo.list_datasets():
+    raise SystemExit(f"Dataset '{NAME}' already exists; inspect or delete it first")
+
+# add-only-what's-missing: right for incremental downloads
+existing = {(s.sequence, s.variant) for s in dataset}
+samples = [s for s in samples if (s.sequence, s.variant) not in existing]
+
+# rebuild cleanly: right while the authoring code is still moving
+if NAME in fo.list_datasets():
+    fo.delete_dataset(NAME)
+```
+
+Datasets should be `persistent=True` unless you want them dropped when the
+database session ends.
+
+**Cached stats go stale.** After re-authoring an episode with different topics,
+the sample's `message_count`, `channel_count`, `topics`, `schemas`, and `has_*`
+fields do not refresh on their own, and a build script that refuses to re-run
+will not update them. Re-read the MCAP and write the fields back:
+
+```python
+s = dataset.first()
+stats = mcap_stats(s.filepath)
+for k, v in stats.items():
+    s[k] = v
+s.save()
+```
+
+## Ambiguous or damaged episodes: ship variants rather than silent repairs
+
+One sequence had a real 2.86 s camera dropout, and the release also shipped a
+clean camera-only re-export on a third clock domain. Merging them would have
+required re-timestamping across clock domains, which is real engineering rather
+than an import-time decision (see
+[MCAP-TROUBLESHOOTING.md §6](MCAP-TROUBLESHOOTING.md#6-timestamps-and-clock-domains)).
+Both were imported as separate samples sharing `sequence="LF-02-N"`,
+distinguished by `variant="original"` and `variant="svo_reexport"`, with an
+honest `has_zed_dropout` flag.
+
+## Temporal tags
+
+`start` and `end` are nanoseconds elapsed since the start of the recording, as a
+half-open interval `[start, end)`. This converts point-in-time markers into
+intervals:
+
+```python
+import fiftyone.core.tags as fota
+
+boundaries = [s["timestamp_ns"] - start_ns for s in subtasks] + [end_ns - start_ns]
+for i, s in enumerate(subtasks):
+    if boundaries[i + 1] > boundaries[i]:
+        dataset.temporal_tags.add(
+            fota.TemporalTag(sample_id, start=boundaries[i], end=boundaries[i + 1],
+                             tag=s["task"]))
+
+# query later
+view = dataset.match_temporal_tags(tags="gripper closed")
+```
+
+Only tag from real event data, and verify the window falls inside the episode.
+
+## Choosing which episodes to import
+
+When a release has far more sequences than you can take, choose on content rather
+than availability. One dataset had 303 candidate sequences that were all
+file-identical in structure, so the selection criteria became GPS quality
+(`RTK_fixed_cm`), no sensor dropout, not flagged degraded, low idle fraction, and
+a spread across sessions and splits. State the rule so the sample is defensible.
+See [Sample large corpora deliberately](#process-discipline) below for how this
+scales to multi-terabyte corpora.
+
+---
+
+## Size, buffering speed, and cost
+
+Ranked by measured impact across real imports:
+
+1. **Raw uncompressed color images**, about 76 % of one scene's uncompressed
+   bytes. JPEG transcode gives roughly 10x reduction — see
+   [MCAP-TROUBLESHOOTING.md §5.8](MCAP-TROUBLESHOOTING.md#58-transcoding-raw-images-and-when-not-to).
+2. **Derived accumulation or map topics**, about 55 % of one episode and the sole
+   cause of a 201 GB blowup, while carrying zero unique information — see
+   [MCAP-TROUBLESHOOTING.md §4.6](MCAP-TROUBLESHOOTING.md#46-accumulated-map-topics-and-how-they-blow-up-file-size).
+3. **The highest-rate, highest-resolution lidar**, 74 % of one scene's payload
+   after the image fix, from three stacked causes: 2x the other lidar's scan
+   rate, 2x its angular resolution, and 2x wasted bytes per point.
+4. **Full-resolution `32fc1` depth**, which alongside the point cloud dominates
+   output size for a dense-ground-truth dataset.
+5. **Per-point padding**, which halves uncompressed bytes and per-message decode
+   cost but saves only about 5 % on disk after zstd — see
+   [MCAP-TROUBLESHOOTING.md §4.3](MCAP-TROUBLESHOOTING.md#43-colour-fields-stride-and-packing).
+6. **zstd level.** `MCAPWriteOptions(compression_level=19)` versus the SDK
+   default of 0, which means "let zstd pick", typically 3. Still lossless, just
+   more CPU per chunk:
+
+   ```python
+   from foxglove.mcap import MCAPWriteOptions
+   with foxglove.open_mcap(path, allow_overwrite=True,
+                           writer_options=MCAPWriteOptions(compression_level=19)):
+       ...
+   ```
+
+Real cost figures from one 20-core NVMe machine, for a roughly 10-minute
+multi-sensor car episode with video, lidar, dense depth, semantic, events, and
+CAN:
+
+| | Per 10 min episode |
+|---|---|
+| Source download, without the event stream | ~9.9 GB |
+| Source download, with events | ~24 GB |
+| Output MCAP | 9–14 GB |
+| Conversion, 4 running in parallel | ~23 min each |
+
+Conversion was largely single-core Python plus a multithreaded `ffmpeg`, measured
+at about 2.5 cores per episode, so 4 jobs on 20 cores was comfortable and cut a
+four-episode run from about 90 minutes serial to about 23.
+
+Two process notes:
+
+- Measure before optimizing. Both size investigations here started from "why does
+  buffering take so long", sampled real per-topic message sizes with the `mcap`
+  reader, and only then changed code.
+- Mixing formats across episodes in one FiftyOne dataset is fine. Each MCAP is
+  self-describing, so you don't have to re-author old episodes to adopt a new
+  packing scheme.
+
+**Downloading:** never pull a large Hub repo without a filter. One stray call
+made while trying to list a 3,058-file repo put 17 GB of partial blobs in the
+cache in about three minutes. Use an API listing call to enumerate, which
+transfers nothing, and a download script that names its episodes explicitly —
+see [HF-HUB-IMPORT.md](HF-HUB-IMPORT.md) for the general Hugging Face download
+patterns this applies on top of.
+
+---
+
+## Validation before declaring success
+
+### Summary read (footer only, no message decode)
+
+Run `mcap_stats()` (above) on every input file and every file you produce. It
+reads the footer, so it is nearly free even on a 25 GB file.
+
+Sanity checks on the output:
+
+- `duration_s` is close to the real recording length. A wildly inflated value
+  means inconsistent timestamps across merged sources — see
+  [MCAP-TROUBLESHOOTING.md §6.6](MCAP-TROUBLESHOOTING.md#66-rebasing-when-merging-sources).
+- `message_count > 0` per file.
+- Every schema either appears in
+  [MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md#schema-to-tile-reference)'s
+  decode table or is knowingly Message-tile only.
+
+### A written file is not a good file
+
+One episode out of eight came out of a parallel run **sparse**: 2.90 GB apparent,
+1.45 GB allocated, with a 1.44 GB hole of zeros starting right after the first
+chunk. Everything about it looked healthy from outside. The summary parsed,
+statistics reported all 74,397 messages, and the chunk index was internally
+consistent, indexing nothing inside the hole and simply jumping 1,445 MB between
+two consecutive chunks. The App read a record length out of the zeros, got
+1152921882580561845, and dropped the transform tree.
+
+Nothing downstream noticed. The converter reported success, the builder ingested
+the file, and the sample carried the right topics, message count, and channel
+count, because all of that comes from the intact summary at the tail. **Only
+opening the sample surfaced it.** This is the single most important reason tile
+verification (below) is not optional, even when every automated check passes.
+
+Two defences, both cheap:
+
+```python
+import os, struct
+
+MCAP_MAGIC = b"\x89MCAP0\r\n"
+
+def validate_mcap(path):
+    """Raise unless every top-level record frames correctly and the file is fully
+    written. Both checks are seek-bound: about 0.9 s to clear 47 GB, against ~80 s
+    for a full message read of a single 13 GB file."""
+    size = os.path.getsize(path)
+    allocated = os.stat(path).st_blocks * 512
+    if allocated < 0.95 * size:
+        raise RuntimeError(f"{path}: sparse file, {allocated / 1e6:.0f} MB allocated "
+                           f"of {size / 1e6:.0f} MB, content is missing")
+    with open(path, "rb") as f:
+        if f.read(8) != MCAP_MAGIC:
+            raise RuntimeError(f"{path}: not an MCAP file")
+        off = 8
+        while off < size - 8:
+            f.seek(off)
+            header = f.read(9)
+            if len(header) < 9:
+                raise RuntimeError(f"{path}: truncated record header at {off}")
+            opcode, length = header[0], struct.unpack("<Q", header[1:])[0]
+            if not 1 <= opcode <= 15 or off + 9 + length > size:
+                raise RuntimeError(f"{path}: bad record at offset {off}: "
+                                   f"opcode {opcode}, length {length}")
+            off += 9 + length
+        if off != size - 8:
+            raise RuntimeError(f"{path}: records end at {off}, expected {size - 8}")
+        f.seek(off)
+        if f.read(8) != MCAP_MAGIC:
+            raise RuntimeError(f"{path}: missing trailing magic")
+```
+
+Either check alone would have caught that file. Run it at the end of every
+conversion, before the file counts as done — and cheaply on every file you
+*import* too, even if you didn't author it, since a corrupted download can look
+identical to a healthy file until opened.
+
+The second defence is process-level. Run parallel conversion pools under `spawn`
+rather than the Linux default `fork`, so a worker never inherits the parent's
+copy of the SDK's writer state:
+
+```python
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+ctx = multiprocessing.get_context("spawn")
+with ProcessPoolExecutor(max_workers=jobs, mp_context=ctx) as pool:
+    futures = {pool.submit(convert_one, job): job[0] for job in jobs}
+    for future in as_completed(futures):
+        record(*future.result())
+```
+
+The fault has not reproduced in a fresh single-job process, so treat it as an
+intermittent fault in a forked pool and defend against it rather than explain it.
+
+### Structural validation of an authored episode
+
+Checks per-topic message counts against counts derived from the source files,
+verifies related products agree, and asserts timestamps are ordered.
+
+```python
+from collections import defaultdict
+from mcap.reader import make_reader
+
+def verify(mcap_path, expected_counts):
+    """expected_counts: {topic: n} derived from the SOURCE files, not the mcap."""
+    ok = True
+    with open(mcap_path, "rb") as f:
+        reader = make_reader(f)
+        summary = reader.get_summary()
+        stats = summary.statistics
+
+        per_topic = defaultdict(int)
+        for cid, n in stats.channel_message_counts.items():
+            per_topic[summary.channels[cid].topic] += n
+
+        dur_s = (stats.message_end_time - stats.message_start_time) / 1e9
+        print(f"{stats.message_count} msgs, {stats.channel_count} channels, {dur_s:.1f}s")
+
+        for topic, want in expected_counts.items():
+            got = per_topic.get(topic, 0)
+            ok &= got == want
+            print(f"  [{'OK ' if got == want else 'FAIL'}] {topic}: {got} (expected {want})")
+
+        # per-channel monotonic log_time, and a full-scan count cross-check
+        last_ts, non_monotonic, n_scanned = {}, defaultdict(int), 0
+        for _s, channel, message in reader.iter_messages():
+            n_scanned += 1
+            prev = last_ts.get(channel.id)
+            if prev is not None and message.log_time < prev:
+                non_monotonic[channel.topic] += 1
+            last_ts[channel.id] = message.log_time
+        if non_monotonic:
+            ok = False
+            print(f"  [FAIL] non-monotonic log_time: {dict(non_monotonic)}")
+        if n_scanned != stats.message_count:
+            ok = False
+            print(f"  [FAIL] scanned {n_scanned} != summary count {stats.message_count}")
+
+    print(f"  => {'PASS' if ok else 'FAIL'}")
+    return ok
+```
+
+Build `expected_counts` from the source data: the number of `.jpg` files in a
+camera directory, rows in an IMU CSV, `.pcd` files, pose rows. Derived products
+should agree with each other too, so if you emit a depth map, an overlay, and a
+normal map per synced frame, all three counts must match, and a per-episode
+calibration message should appear exactly once.
+
+### Dataset-level checks
+
+```python
+dataset = fo.load_dataset(NAME)
+assert dataset.media_type == "multimodal"
+assert len(dataset) == expected_episode_count
+for s in dataset:
+    assert s.filepath.endswith(".mcap") and os.path.exists(s.filepath)
+```
+
+Report any mismatch with numbers. Do not declare success on a count you did not
+check.
+
+### Tile verification is a human step, and it is not optional
+
+Nothing above proves a tile renders. Launching the App is the user's action:
+
+```python
+session = fo.launch_app(dataset)
+```
+
+Ask them to confirm, with the App open:
+
+- the grid shows a stream preview per episode (the stream selector picks which);
+- opening a sample and adding tiles produces real decoded data for each
+  capability flag that was set;
+- the 3D tile's reference frame is the tree root, and geometry is placed rather
+  than sitting at the origin (see
+  [MCAP-TROUBLESHOOTING.md §3.4](MCAP-TROUBLESHOOTING.md#34-reference-frames-tree-roots-and-disconnected-components));
+- the timeline duration matches the sample's `duration_s`.
+
+Before concluding a tile is broken, also check whether you're just early in
+playback — many tiles legitimately show nothing until their topic's first
+message ([MCAP-TROUBLESHOOTING.md §6.7](MCAP-TROUBLESHOOTING.md#67-real-gaps-that-look-like-bugs-but-arent)) —
+and check [MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md#symptom--cause--fix-triage-table)
+for the specific symptom before assuming a bug.
+
+Some imports stop short of this step, and the honest thing to record is "not yet
+visually verified in the App, don't assume the tiles were checked" — never
+report success on the strength of a passing automated check alone.
+
+---
+
+## Non-negotiables
+
+Read before writing any authoring or conversion code:
+
+1. **One sample = one episode = one `.mcap` file.** The sample's `filepath` must
+   end in `.mcap`, which is what sets `media_type == "multimodal"`.
+2. **Inspect before you import, and validate everything you write.** The summary
+   read is footer-only and nearly free. The structural check is seek-bound and
+   clears 47 GB in about a second. A file that was written is not the same as a
+   file that is good.
+3. **Never fabricate data to make a tile render.** Omission is always allowed,
+   invention never. Skip a zero-point scan rather than logging fake points; leave
+   a camera frustum unplaceable rather than inventing extrinsics that were never
+   recorded; fall back to greyscale-from-intensity rather than a made-up color.
+4. **Verify calibration numerically against the data, not against the paper or
+   the devkit.** Papers and devkits were wrong or self-contradictory in at least
+   seven real datasets — see
+   [MCAP-TROUBLESHOOTING.md §3.7](MCAP-TROUBLESHOOTING.md#37-frames-that-cannot-be-connected-and-conventions-that-bite).
+5. **Prove one episode end-to-end in the App before batch-authoring the rest.**
+   One import shipped 20 files before confirming a single one and had to redo
+   them all.
+6. **A working build is not a correct one.** Exit code 0 with plausible message
+   counts held true at every stage of one multi-day debugging session, including
+   the stages later found broken. Decoding real messages back out and checking
+   actual values is what caught each bug.
+7. **Derive capability flags from schema names, never topic-name substrings.** A
+   topic called `/os_node/imu_packets` was a raw packet blob, not a decodable
+   `Imu`. See [above](#capability-flags-from-schemas-not-topic-names).
+8. **Write down what you verified, in the code.** Every non-obvious constant
+   should carry the measurement that justifies it.
+
+## Process discipline
+
+1. **One episode, confirmed in the App, before the batch.** (Non-negotiable 5.)
+2. **Treat the output path as a lock, and validate every file.** Two agent
+   sessions independently started the same authoring script 18 s apart, both
+   wrote the same output path, and the result was silent corruption with no
+   error. `foxglove.open_mcap(..., allow_overwrite=True)` gives no protection
+   against two writers racing on one path.
+3. **Cheap re-authoring buys freedom.** One dataset could re-author all 36
+   episodes in about 35 s, so three separate bugs were fixed without agonizing.
+   Budget for this, because it changes which decisions are reversible.
+4. **Write the numbers down in the code.** Every non-obvious constant should
+   carry the measurement behind it: why a z-offset is -2.20, why a pitch is 0.0
+   rather than the paper's 15°, why intensity is safe as `uint8`.
+5. **Record what you deliberately did not do**, with the reason: an unfixable
+   camera frustum, an unused second pose CSV, an excluded topic, a field whose
+   semantics you could not confirm.
+6. **Keep failed analyses as evidence.** The two scripts that failed to recover a
+   radar's geometry are kept beside the one that succeeded, so their failure
+   modes stay legible and nobody refits those constants a second time.
+7. **Present judgment calls as explicit choices** with real numbers attached,
+   rather than picking silently.
+8. **Sample large corpora deliberately.** A 3.04 TB dataset was sampled as 20
+   episodes stratified by size percentile per operator; an 8.94 TB dataset as the
+   smallest full episode per task; a 9.4 TB dataset as one 30-second window per
+   trajectory type.
+9. **Cross-check the paper against the shipped files, both ways.** Real findings:
+   a paper claiming per-image depth maps that exist in no sequence; a card
+   quoting 2,203 episodes when 1,639 are uploaded; a documented 17-topic list
+   when the bags carry 33; radar files with 3 more fields than documented; and a
+   dataset with no bounding boxes at all despite the impression its description
+   gives, verified against the full repo listing, the complete file tree, and the
+   devkit.
+
+## Dataset case index
+
+Provenance for the findings across this skill's reference files, from real
+imports of 16 robotics/AV datasets (ROS 1 bags, ROS 2 bags, Zarr and HDF5
+exports, raw dumps of images, video, point clouds, radar, events, audio, GPS,
+and IMU). These are internal dataset names — you never need to look them up —
+listed so a lesson can be traced back to the import that produced it, and so a
+future finding can be filed alongside the right one.
+
+| Dataset | Path | Lessons it produced |
+|---|---|---|
+| `octosense` | C (HDF5 + video) | the 50 ms transform rule and untimestamped statics; H.264 encoder constraints; `mcap.calibration_topic`; camera geometry inference and the 0.5 px tolerance; depth encodings; JSON schema for Plot; uint8 colour; sparse-file corruption and `validate_mcap`; `spawn` pools; reading the viewer bundle; fitted radar constants |
+| `grand_tour` | C (Zarr) | mixed static and dynamic chains failing to resolve; reference frame must be the tree root; disconnected coordinate roots; global time-span padding; Zarr chunk preloading; no `Imu` in foxglove-sdk; `Pose.position` needs `Vector3`; `JointStates`; `CompressedImage(format="png")` over `RawImage`; 16-bit depth pre-colorization; `kannala_brandt` Auto gap and the ImageAnnotations workaround; stale sample stats |
+| `navwareset` | B (merge 2 ROS 1 bags) | topic and `frame_id` collisions; `CameraInfo` casing; static topic naming; planar-tf noise flattening; JPEG transcode; PointCloud2 repack; redundant-topic exclusion; devkit offset-convention math |
+| `semanticspray` | C (author from raw) | one-shot transform expiry; skipping zero-point clouds; dropped class names; mount-height leakage in a "z" column; assumed-FPS timestamps; sample fields vs MCAP content |
+| `yuto_mms` | C | 201 GB accumulation blowup and dry-run sizing; voxel prefix-slice trick; real RGB colorization; per-sequence calibration parsing; per-sequence timestamp conventions; concurrent-writer corruption; lossless `uint8` intensity; zstd 19 |
+| `costnav_telepp` | A (patch existing) | ROS2-CDR PointCloud2 freeze vs foxglove.PointCloud; promoting rigid transforms to the static topic; byte-copy patch pattern; rosbag2 metadata bookkeeping; `CompressedImage.format` parsing; source-metadata vs file mismatch |
+| `boreas` | C (devkit-driven) | GPS lat/lon in radians; era-dependent CSV columns; era-gated radar Doppler correction; box metadata via `KeyValuePair`; devkit-faithful box filtering; BEV footprint annotations |
+| `oxford_spires` | C | topic tokens for geometry auto-detect; direct root-to-sensor transforms; PCL packed-rgb unpacking; field alignment and stride; fisheye calibration; the structural validation script |
+| `canoe_dataset` | C (devkit-driven) | nearest-in-time sensor pairing; pre-baked lidar-on-camera overlay as its own JPEG topic; zero-return range filter; calibration logged once; CSV with a free-text header block |
+| `fomo_dataset` | C | audio via `RawAudio`; polar and BEV radar images; static transforms from a transforms.json; arbitrary metadata CSVs as JSON channels; alpha-strip on PNG; ground truth recentered to a per-episode origin |
+| `uosm_campus` | A | `log_time` vs `header.stamp` clock domains; dropout and re-export variants as separate samples; calibration in `dataset.info`; incremental add-only import |
+| `xiangrui_rosbag2` | A (split) | splitting at a real mode signal; message-count conservation; 101 s startup dead zone; undecodable vendor schemas; documenting missing transforms and calibration rather than faking them |
+| `hiw_500` | A | temporal tags from point markers; per-episode metadata and calibration sidecars; smallest-episode-per-task sampling |
+| `maritime_lidar_scenarios` | A | ground-truth extrinsics as sample fields for a calibration benchmark; cross-checking MCAP topics against exported point-cloud folder counts |
+| `msc_rad4r_dataset` | B | bag vs exploded-frames tradeoff, decided on timestamps; size-gated conversion script; download quota walls |
+| `race16` | C (recon only) | color/depth index offset across shard boundaries; unconfirmed depth units; dummy all-zero IMU orientation; when a flat per-frame dataset may beat a single-episode one |
+
+## The two companion docs to write per dataset
+
+Worth reproducing for every dataset you import or author. Together they are what
+makes an import reviewable, resumable by someone else, and traceable months
+later — and are how the case index above and this whole skill got assembled in
+the first place.
+
+- **A recon doc** (facts): source, paper, license, download size; media table
+  with modality, count, format, and verified details; a mapping table from source
+  labels to FiftyOne or MCAP representations; other contents (splits, metadata,
+  calibration, precomputed extras); structure recommendation with reasoning;
+  numbered focus areas for import; and discrepancies between what the
+  documentation claims and what the files contain.
+- **An onboarding doc** (narrative): the architecture decision and why; decisions
+  in order with reasoning; what actually made the import hard, with verified
+  fixes rather than guesses; open questions and risks; a current-state table; key
+  files; and a short "if you're picking this up cold" section.
+
+Four rules for maintaining the onboarding doc:
+
+- **Write down dead ends and their evidence.** A negative result that cost an
+  hour is worth as much as a fix. A section explaining why some constants were
+  fitted a particular way exists so nobody refits them a second time.
+- **Record the number, not the impression.** "r = +0.13 against the depth ground
+  truth" survives being read six months later. "The radar looked off" does not.
+- **File it by kind.** Viewer behaviour goes in the symptom table
+  ([MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md#symptom--cause--fix-triage-table)),
+  source-data behaviour in the quirks list
+  ([MCAP-AUTHORING.md §5](MCAP-AUTHORING.md#5-source-formats-zarr-hdf5-pcd-csv)),
+  and anything that took a real investigation gets its own section.
+- **Correct wrong entries in place rather than appending.** One radar was written
+  up as effectively empty on the strength of one short episode; measurement later
+  showed about 54,600 detections, so the original line was replaced, not
+  annotated.
+
+Keep the doc honest about what has not been verified. A line like "not yet
+visually verified in the App, don't assume the tiles were checked" is what stops
+the next person from treating an unfinished import as done.

--- a/skills/fiftyone-dataset-import/MCAP-TROUBLESHOOTING.md
+++ b/skills/fiftyone-dataset-import/MCAP-TROUBLESHOOTING.md
@@ -1,0 +1,1332 @@
+# MCAP troubleshooting: symptoms, the viewer contract, and rendering rules
+
+Read this when a multimodal tile isn't rendering what you expect, on files from
+any path (authored, converted, or already-existing). Start with the symptom
+table immediately below. If you're producing/converting MCAP files rather than
+debugging one, see [MCAP-AUTHORING.md](MCAP-AUTHORING.md). For building/validating
+the FiftyOne dataset itself, see [MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md).
+
+## Contents
+
+1. [Symptom → cause → fix triage table](#symptom--cause--fix-triage-table)
+2. [The viewer contract](#2-the-viewer-contract)
+3. [Frames and transforms](#3-frames-and-transforms)
+4. [Point clouds](#4-point-clouds)
+5. [Images, cameras, video, and calibration](#5-images-cameras-video-and-calibration)
+6. [Timestamps and clock domains](#6-timestamps-and-clock-domains)
+
+---
+
+## Symptom → cause → fix triage table
+
+Most of the App's rendering failures are **silent** — no error names the cause.
+Check this table before assuming something is broken.
+
+| Symptom in the App | Root cause | Fix |
+|---|---|---|
+| `Missing transform to <frame>`, or the 3D tile shows content "in local coordinates" | Rig extrinsics were logged with a timestamp. The viewer only treats a transform as static when it carries no timestamp; a timestamped edge is usable only within 50 ms of the playhead | Log static edges with no timestamp at all — [§3.1](#31-the-two-transform-stores-and-the-50-ms-rule) |
+| Point clouds render briefly at the start, then vanish; Image tile keeps playing | Same cause as above, seen from the other side: a one-shot transform at `t0` covers only the beginning of playback | Omit the timestamp for true statics, or re-log a genuinely dynamic transform at every frame — [§3.1](#31-the-two-transform-stores-and-the-50-ms-rule) |
+| `Missing transform to <root>` for every sensor, even after padding the dynamic backbone to the full episode | A chain mixing a dynamic hop (`odom→base`) with a static hop (`base→sensor`) did not resolve reliably | Precompute `T_root_sensor(t)` and log one direct dynamic hop per sensor, then remove that child from the static topic so it has one parent — [§3.3](#33-when-a-mixed-static-and-dynamic-chain-will-not-resolve) |
+| Setting the 3D tile's reference frame makes everything disappear | Reference was a leaf frame. Resolution walks root to descendant, so from a leaf nothing resolves, not even its own ancestors | Set the reference selector to the tree root — [§3.4](#34-reference-frames-tree-roots-and-disconnected-components) |
+| Whole App freezes when opening an episode with a big accumulated cloud | The ROS2-CDR `PointCloud2` decode path has a size-scaling problem the Foxglove-protobuf `PointCloud` path does not | Author large or accumulated clouds as `foxglove.PointCloud` — [§4.1](#41-large-ros2-cdr-pointcloud2-can-freeze-the-app-foxglovepointcloud-does-not) |
+| `Failed to load: <topic>` on a point-cloud topic, only on some frames | The sensor returned 0 points on those scans. The message is spec-valid but the renderer chokes | Skip the log call for zero-point scans — [§4.2](#42-skip-zero-point-scans-instead-of-logging-an-empty-message) |
+| Point cloud renders but the colours are wrong or washed out | Colour packed as float. Integer fields are normalised by their own max, but a float field is divided by 255 only when a value exceeds 2 | Pack colour as `uint8` — [§4.3](#43-colour-fields-stride-and-packing) |
+| `Failed to load` on every `*/camera_info` channel | ROS 1 `CameraInfo` keeps uppercase `D/K/R/P`; ROS 2 renamed them lowercase, so the frustum code finds them undefined | Override `sensor_msgs/msg/CameraInfo` with canonical ROS 2 fielddefs in both typestores — [§5.1](#51-camerainfo-field-casing-silent-frustum-failure) |
+| Point cloud renders, but cameras do not project | The image topic is not tied to its calibration | Set channel metadata `mcap.calibration_topic` — [§5.2](#52-pair-every-image-topic-with-its-calibration) |
+| `Original and rectified camera models differ; choose the image geometry` | The topic name gives no geometry hint and the `K`+`D` model disagrees with `P` by more than the tolerance | Last path segment must contain `image` plus `raw` or `rect` — [§5.3](#53-topic-names-decide-the-camera-geometry) |
+| `Rectified projection is available, but Auto cannot prove the image uses it: Unsupported distortion model 'kannala_brandt'` | Gap in the Auto rectified-projection detection for fisheye models. The calibration itself is valid, since frustums still render | Precompute the projection and log it as an `ImageAnnotations` overlay, which is decoded independently — [§5.6](#56-distortion-models) |
+| Projection lands in the wrong place | Calibration `R` repeats a rotation the transform tree already applies | Set `R` to identity when the rectified frame is a real frame in the tree — [§5.4](#54-calibration-r-and-double-rotation) |
+| Depth image displays but has no metric value | Encoding is `mono16` | Use `16uc1` (millimetres) or `32fc1` (metres) — [§5.5](#55-depth-and-other-non-rgb-image-data) |
+| 16-bit depth PNG displays as solid black | A 700 mm value is about 1 % brightness as raw 16-bit grey, and passing the PNG through `CompressedImage` gets no depth-aware normalisation | Pre-colorize with a fixed range and colormap, then log 8-bit — [§5.5](#55-depth-and-other-non-rgb-image-data) |
+| No video anywhere | Source is HEVC and the decoder only takes H.264 | Transcode to H.264 Annex-B, one access unit per message — [§5.7](#57-video) |
+| No video, and it is already H.264 | The stream contains B-frames, which are rejected outright | Encode with `-bf 0` — [§5.7](#57-video) |
+| `Timed out waiting for H.264 frame decode` | `h264_nvenc` bitstream. It passes `isConfigSupported` and then never emits a frame | Encode with `libx264` — [§5.7](#57-video) |
+| Video plays only from frame 0 | SPS/PPS written once at the head | `-bsf:v dump_extra=freq=keyframe` — [§5.7](#57-video) |
+| Telemetry cannot be plotted | The JSON channel has an auto-generated schema | Declare a JSON schema with typed properties — [MCAP-AUTHORING.md §2](MCAP-AUTHORING.md#2-authoring-gaps-in-foxglove-sdk) |
+| `Frame transforms failed to load`, or `Record content length <absurd> is too large` | The file on disk is sparse: a hole of zeros sits between two chunks. The summary at the tail still parses, so nothing downstream notices | Gate every conversion on `validate_mcap()`, and run parallel pools under `spawn` — [MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#a-written-file-is-not-a-good-file) |
+| A transform channel behaves as if it isn't static | The static store is keyed on the topic name, and a suffix breaks the match | Name it `/tf_static` or `/<prefix>/tf_static`, never with a suffix — [§3.2](#32-topic-naming-for-the-static-store) |
+| Two sensors' clouds are visibly on different planes or tilted | Non-physical roll/pitch/z noise on a localization `/tf` chain | Flatten the specific `(parent, child)` pairs carrying it to yaw-only with `z=0` — [§3.6](#36-flattening-non-physical-pose-noise) |
+| Pose or trajectory jumps erratically after merging two bags | Both sources wrote the same topic into one channel | Prefix or remap one source's topics before merging — [§3.5](#35-merging-bags-topic-collisions-and-frame_id-collisions-are-two-bugs) |
+| Timeline spans days or weeks with slivers of data | Sources merged without timestamp rebasing | `offset = anchor.start_time - other.start_time` — [§6.6](#66-rebasing-when-merging-sources) |
+| `struct.error: unpack_from requires a buffer of at least N bytes`, or a `UnicodeDecodeError` from a shifted string read | One typestore used for both ROS 1 deserialize and ROS 2 serialize. ROS 1's `Header` has an extra `uint32 seq` | Use two typestores — [MCAP-AUTHORING.md §3.2](MCAP-AUTHORING.md#32-ros-1-to-ros-2-cdr-by-hand-two-typestores-always) |
+| `AttributeError: 'bytes' object has no attribute 'view'` while serializing | `rosbags`' CDR serializer expects sequence-of-primitive fields as numpy arrays | `np.frombuffer(payload, dtype=np.uint8)` first — [§5.8](#58-transcoding-raw-images-and-when-not-to) |
+| One topic silently splits into two channels with the same name | A ROS 1 bag carries a legacy type name for a canonical type | Alias legacy msgtypes before keying anything on them — [MCAP-AUTHORING.md §3.3](MCAP-AUTHORING.md#33-legacy-msgtype-aliases) |
+| Output MCAP is corrupt garbage, no error raised | Two processes wrote the same output path concurrently, with no locking | Treat the output path as a lock, and validate every file — [MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#process-discipline) |
+| Authored file is absurdly large (for example 201 GB) | An accumulation topic's tuning constants were copy-pasted from a shorter episode | Run a dry-run size estimate per episode — [§4.6](#46-accumulated-map-topics-and-how-they-blow-up-file-size) |
+| Build takes 27 minutes instead of 1 | A Zarr array stored as one chunk is re-decompressed on every `arr[i]` access inside a loop | Preload with `arr[:]` once, then index the numpy array — [MCAP-AUTHORING.md §5.1](MCAP-AUTHORING.md#51-zarr) |
+| `can't open directory (/usr/local/lib/plugin)` from `h5py` | The arrays use Blosc2 or Zstd filters and `hdf5plugin` was not imported in that process | Import `hdf5plugin` in every worker process — [MCAP-AUTHORING.md §5.2](MCAP-AUTHORING.md#52-hdf5) |
+| Grid preview is blank | Wrong stream selected for the preview | Use the grid's stream selector |
+| Map tile empty | No `NavSatFix` or `LocationFix`, values are 0/NaN, or lat/lon are in radians | Check units before blaming the tile — [§6.5](#65-units-especially-for-gps) |
+| A topic is listed but no tile will render it | No built-in decoder for that schema | Nothing to fix, it is Message tile only — [§2](#2-the-viewer-contract) |
+| A tile shows nothing (or "No message at or before the playhead on this topic") right at the start of playback | That topic's first message may genuinely not start at `t=0` — real recording-startup delay is common | Scrub or play forward before concluding it's broken — [§6.7](#67-real-gaps-that-look-like-bugs-but-arent) |
+
+If your symptom isn't here, check the silent-failure list below, or use the
+bundle-reading technique to find the answer yourself and consider adding the
+finding back to this table.
+
+---
+
+## 2. The viewer contract
+
+The FiftyOne multimodal viewer accepts a narrower slice of what MCAP/ROS/Foxglove
+schemas technically allow, and it mostly fails **silently**. A stream that
+violates one of the rules on this page renders as nothing at all, usually with
+no error naming the cause.
+
+### Schema to tile reference
+
+This table matches the official
+[Supported schemas](https://docs.voxel51.com/user_guide/multimodal.html#supported-schemas)
+list. Built-in decoders exist for ROS 1 and ROS 2 (CDR), Foxglove (protobuf and CDR),
+and JSON-encoded versions of the same schemas. Anything else still appears in
+the Message tile, which is fine. Note it and move on, don't treat it as a bug.
+
+| Tile | ROS schemas | Foxglove schemas |
+|---|---|---|
+| Image | `sensor_msgs/msg/Image`, `sensor_msgs/msg/CompressedImage` | `RawImage`, `CompressedImage`, `CompressedVideo` (H.264 only, see [§5.7](#57-video)) |
+| Image overlays | `vision_msgs/msg/Detection2DArray` | `ImageAnnotations` |
+| 3D | `sensor_msgs/msg/PointCloud2`, `sensor_msgs/msg/LaserScan`, `nav_msgs/msg/OccupancyGrid`, `nav_msgs/msg/Odometry`, `nav_msgs/msg/Path`, `geometry_msgs/msg/PoseStamped`, `geometry_msgs/msg/PoseArray`, `geometry_msgs/msg/TransformStamped`, `tf2_msgs/msg/TFMessage`, `visualization_msgs/msg/Marker`/`MarkerArray`, `vision_msgs/msg/Detection3DArray` | `PointCloud`, `LaserScan`, `Grid`, `SceneUpdate`, `FrameTransform`/`FrameTransforms`, `PoseInFrame` |
+| Camera frustum (drawn in the 3D tile, paired to an Image-tile topic) | `sensor_msgs/msg/CameraInfo` | `CameraCalibration` |
+| Map | `sensor_msgs/msg/NavSatFix` | `LocationFix` |
+| Logs | `rcl_interfaces/msg/Log` (ROS 2), `rosgraph_msgs/Log` (ROS 1) | `Log` |
+| Plot | any numeric field path on a decodable topic | same |
+| Message | any topic, decoded or not | same |
+
+`diagnostic_msgs/msg/DiagnosticArray` is also a built-in ROS schema, decoded but
+without a dedicated tile of its own.
+
+A few schemas render in practice (confirmed by opening real recordings in the
+App, including in this skill's own testing) but aren't in the official
+Supported schemas list above, most likely because the Plot tile decodes *any*
+numeric field on *any* decodable topic rather than requiring a per-schema
+entry: `sensor_msgs/msg/Imu` plots its `linear_acceleration`/`angular_velocity`
+fields this way. Treat schemas outside the official list as unconfirmed rather
+than assuming they render, and re-check the live docs page if precision
+matters.
+
+Schemas confirmed to have **no** built-in decoder, which show up in the Message
+tile only: `sbg_driver/msg/*` (a rich GNSS/INS vendor format), `can_msgs/msg/Frame`,
+`bond/msg/Status`, `rosbag2_interfaces/*`, `lifecycle_msgs/*`, Livox's
+`livox_ros_driver/msg/CustomMsg`, and raw vendor packet blobs like
+`ouster_ros/msg/PacketMsg`.
+
+Mixing ROS-schema topics and Foxglove-schema topics in a single `.mcap` is
+supported and works. This matters when authoring large point clouds. See
+[§4.1](#41-large-ros2-cdr-pointcloud2-can-freeze-the-app-foxglovepointcloud-does-not).
+
+**A topic's name is not a reliable signal for what it renders as.** A topic
+named `/lidar` or `/imu_packets` looks like LiDAR or IMU data, but if its actual
+message schema isn't in the table above, it will never render in the 3D or
+Plot tile no matter how the topic is named. It always falls back to the
+Message tile. Derive capability flags (`has_pointcloud`, `has_image`, etc.) from
+real schema names read out of the file, never from topic-name substrings. See
+[MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#capability-flags-from-schemas-not-topic-names).
+
+### The silent-failure list
+
+Every one of these renders as nothing, with no error naming the cause.
+
+| Rule | Where it's explained |
+|---|---|
+| Static transforms must carry no timestamp; a timestamped one expires 50 ms after the playhead passes it | [§3.1](#31-the-two-transform-stores-and-the-50-ms-rule) |
+| The static store is populated from topics whose name matches `tf_static`, and holds at most 256 messages | [§3.2](#32-topic-naming-for-the-static-store) |
+| A chain mixing a static hop and a dynamic hop may not resolve; precompute a direct dynamic hop instead | [§3.3](#33-when-a-mixed-static-and-dynamic-chain-will-not-resolve) |
+| The 3D tile's reference frame must be the tree root, since resolution walks root to descendant | [§3.4](#34-reference-frames-tree-roots-and-disconnected-components) |
+| An image topic needs `mcap.calibration_topic` channel metadata to project against its calibration | [§5.2](#52-pair-every-image-topic-with-its-calibration) |
+| The topic's last path segment must contain `image` plus `raw` or `rect` when `K`+`D` and `P` disagree | [§5.3](#53-topic-names-decide-the-camera-geometry) |
+| Depth needs `16uc1` (millimetres) or `32fc1` (metres); `mono16` displays but carries no metric value | [§5.5](#55-depth-and-other-non-rgb-image-data) |
+| Calibration `R` must be identity when the rectified frame is itself a frame in the tree | [§5.4](#54-calibration-r-and-double-rotation) |
+| Video must be H.264, no B-frames, `libx264` not `h264_nvenc`, SPS/PPS on every keyframe | [§5.7](#57-video) |
+| Point cloud colour fields should be `uint8`, because float colour is ambiguous | [§4.3](#43-colour-fields-stride-and-packing) |
+| A zero-point cloud message makes the topic fail to load on that frame | [§4.2](#42-skip-zero-point-scans-instead-of-logging-an-empty-message) |
+| JSON channels need a declared schema to be plottable | [MCAP-AUTHORING.md §2](MCAP-AUTHORING.md#2-authoring-gaps-in-foxglove-sdk) |
+
+### Answering viewer questions yourself
+
+None of the above is officially documented in most places. It was recovered from
+the shipped JavaScript bundle, and you can do the same when this skill goes
+stale or your FiftyOne version differs:
+
+```bash
+cd "$(python -c 'import fiftyone, os; print(os.path.dirname(fiftyone.__file__))')/server/static/assets"
+ls index-*.js playback-worker-*.js
+```
+
+`index-*.js` holds the scene graph, transform resolution, and camera models.
+`playback-worker-*.js` holds the MCAP decode path: schemas, image encodings,
+point fields. Filenames carry a content hash and change with every FiftyOne
+version, so glob them. The code is minified but keeps string literals, which is
+enough.
+
+Three approaches that worked:
+
+1. **Grep the error text you see in the UI**, with a wide context window, to find
+   the function that produced it: `rg -o '.{700}Original and rectified.{500}'`.
+2. **Follow the minified identifiers.** They are stable within one bundle, so
+   once you have a name like `boundaryClampNs` or `addStatic`, grep it to find
+   callers and defaults: `rg -o 'f4e=.{0,300}'`.
+3. **Grep the schema name or encoding string you are about to emit**, to see
+   whether it is handled at all: `rg -o 'case"mono16".{0,700}'`.
+
+Two habits that repeatedly paid off:
+
+- **Verify by rendering, not by reasoning.** Extrinsics that look right in a
+  matrix are worthless as evidence. Project the lidar into the camera and check
+  whether tree trunks land on tree trunks. Read colours back out of the written
+  MCAP and re-project them to prove the packing and field offsets are right.
+- **Check what you actually wrote, not what you meant to write.** A roughly
+  20-line varint walker over a protobuf payload answers "is field 1 present?"
+  without needing the schema, which is how an untimestamped-transform fix was
+  once confirmed. It is the fastest way to prove a field is absent.
+
+If the viewer reports a timeout on a video bitstream that looks conformant, the
+decisive test is a standalone HTML page driving `VideoDecoder` with the same
+one-chunk-in, one-frame-out logic as the viewer, fed both candidate encodings.
+Reproducing a suspected platform bug outside the app is much faster than
+bisecting inside it.
+
+---
+
+## 3. Frames and transforms
+
+More than half of the "the viewer is broken" symptoms observed across real
+imports were transform problems. §3.1 is the mechanism; everything else follows
+from it.
+
+### 3.1 The two transform stores, and the 50 ms rule
+
+Recovered by reading the viewer bundle (see [above](#answering-viewer-questions-yourself)).
+The viewer keeps two stores:
+
+- **Static.** Populated by a bootstrap pass over topics whose name matches
+  `tf_static`, holding at most **256 messages**, and keeping **only the
+  transforms whose timestamp field is absent**. These are valid for all time.
+- **Dynamic.** Everything else. A sample is usable only within `boundaryClampNs`
+  of the playhead, which is **50 ms**.
+
+So the natural thing to write, rig extrinsics stamped once at `t=0` on
+`/tf_static`, resolves for the first 50 ms of playback and is reported missing
+forever after. Omit the timestamp and it holds:
+
+```python
+import numpy as np
+from scipy.spatial.transform import Rotation
+from foxglove.messages import FrameTransform, Quaternion, Vector3
+
+def transform_from_matrix(t_ns, parent, child, T):
+    """FrameTransform for a 4x4 matrix. Omit t_ns to make the edge valid for all time.
+
+    The viewer only treats a transform as static when it carries no timestamp,
+    and a timestamped edge is usable only within 50 ms of the playhead.
+    """
+    x, y, z, w = Rotation.from_matrix(np.asarray(T[:3, :3], dtype=np.float64)).as_quat()
+    stamp = {} if t_ns is None else {"timestamp": ts(t_ns)}
+    return FrameTransform(
+        parent_frame_id=parent,
+        child_frame_id=child,
+        translation=Vector3(x=float(T[0, 3]), y=float(T[1, 3]), z=float(T[2, 3])),
+        rotation=Quaternion(x=float(x), y=float(y), z=float(z), w=float(w)),
+        **stamp,
+    )
+```
+
+The corollary: a frame relationship that genuinely changes over time must be
+emitted as repeated dynamic samples, at the rate of whatever it is attached to.
+In one dataset, `world` (GPS-fused) and `map` (lidar-inertial) drift 28 m and 5.6°
+apart over 53 s, so they get one edge per fused pose. Chaining them with a single
+static offset would look right at `t=0` and be wrong everywhere else.
+
+When you cannot omit the timestamp, for example because you are converting a bag
+whose `/tf` carries stamped transforms, the workaround is to re-log the constant
+value at every frame, which keeps a sample within the clamp window at all times:
+
+```python
+for i, scan_id in enumerate(scan_ids):
+    t_ns = t0_ns + i * dt_ns
+    tf_ch.log(build_static_tf(calib, t_ns), log_time=t_ns)   # same values, new stamp
+```
+
+That cost a few hundred bytes per scan and fixed point clouds that had been
+disappearing partway through playback. After the fix, the transform topic's
+message count equals every other topic's count per episode, which is a cheap
+invariant to assert.
+
+Note that a ROS `TransformStamped` always carries a `Header` with a stamp, so ROS
+static transforms cannot be untimestamped the way a Foxglove `FrameTransform`
+can — if a conversion reports missing transforms, that's the first thing to
+test. See [MCAP-AUTHORING.md](MCAP-AUTHORING.md#4-merging-splitting-and-patching-mcap-files)
+for the full ROS 1→2 conversion path.
+
+### 3.2 Topic naming for the static store
+
+Both readings of the bundle agree that a topic named `/tf_static`, or
+`/<prefix>/tf_static`, lands in the static store. One reading has the tokenizer
+splitting on `[/.:-]+` so that a path segment must be exactly `tf_static`;
+another describes it as tokenizing to `tf` plus `static`. Naming the topic
+`tf_static` satisfies both.
+
+What is verified in practice: a suffix breaks it. A topic named
+`/grs/tf_static_authored` silently behaved as a dynamic channel. Multiple static
+channels under different prefixes work fine, which is useful when merging
+sources: `/tf_static`, `/grs/tf_static`, `/robot/tf_static`,
+`/connector/tf_static` were all in use in one merged episode.
+
+The 256-message cap means you should batch rig extrinsics into a small number of
+`FrameTransforms` messages rather than one message per edge per frame.
+
+Historical note worth keeping: a topic-naming bug and a `CameraInfo` casing bug
+(see [§5.1](#51-camerainfo-field-casing-silent-frustum-failure)) once presented
+as the same symptom, and fixing the first did not clear it. Fixing one cause and
+seeing the symptom persist is not evidence the fix was wrong.
+
+### 3.3 When a mixed static and dynamic chain will not resolve
+
+One import hit a wall that §3.1 does not obviously explain. Every sensor reported
+`Missing transform to odom`, including sensors exactly one static hop from `base`,
+and it persisted after the dynamic `odom → base` edge was correctly padded to
+cover the full episode. Flattening two static hops into one was real progress and
+still not sufficient.
+
+What worked was removing the chaining entirely. For every actively rendered
+sensor, precompute the full root-to-sensor transform and log it as a single
+direct dynamic hop:
+
+```python
+DIRECT_ODOM_SENSORS = {          # frame_id -> T_base_sensor (static, from calibration)
+    "alphasense_right": t_base_alpharight,
+    "hdr_front": t_base_hdrfront,
+    "livox_lidar": t_base_livox,
+}
+
+# per sensor, at that sensor's own timestamps:
+T_odom_sensor = odom_lookup(t) @ T_base_sensor
+log_tf(child_frame_id=sensor_frame, t_ns=t_ns, *decompose(T_odom_sensor))
+
+# and remove those same children from the static topic, so no frame has two parents
+static_frame_transforms = [
+    ft for ft in all_static if ft.child_frame_id not in DIRECT_ODOM_SENSORS
+]
+```
+
+Two requirements, both sides of it:
+
+1. Log the direct `root → sensor` hop at that sensor's own timestamps, using
+   interpolation or extrapolation of the pose track. Doing it at the sensor's own
+   rate also solves the coverage problem in §3.4 for free.
+2. Remove the same `child_frame_id` from the static topic, or the frame ends up
+   with two registered parents.
+
+**A likely explanation, not verified.** That import logged its static transforms
+*with* a timestamp, which by §3.1's rule would have kept them out of the static
+store entirely and made them dynamic samples valid for 50 ms around `t=0`. That
+alone would produce exactly the reported symptom. The two findings come from
+different machines and possibly different FiftyOne versions, and neither was
+tested against the other. If you hit this, try the untimestamped static edge
+first, since it is a one-line change, and fall back to precomputed direct hops if
+that does not clear it.
+
+### 3.4 Reference frames, tree roots, and disconnected components
+
+The 3D tile resolves relative to a reference frame, and the resolver walks root to
+descendant, not descendant to root. Picking a leaf frame (say a lidar) as the
+reference strands everything else, including that leaf's own ancestors. If the
+scene looks empty, check the reference-frame selector before suspecting your data.
+
+A dataset can legitimately have several disconnected coordinate roots. One had
+four: leg-odometry `odom`, a SLAM `dlio_map`, a GNSS `enu_origin`, and an external
+total-station frame with no parent at all. That is intentional, since the point is
+comparing independent localization solutions, and there is no real calibration
+linking them. The practical consequence is that only one connected component
+resolves as "the scene" at a time. Don't force them into one tree.
+
+Also make sure the backbone transform covers the whole episode, not just its own
+native sample range. In one mission a camera's first frame was 0.15 s before the
+first odometry sample, and other streams ran up to 17 s past the last one, so
+anything under `base` had no resolvable transform at the start and end of
+playback:
+
+```python
+def global_time_span(topics):
+    """[first, last] across every stream, so the backbone transform can be padded
+    to cover the whole episode rather than one topic's narrower span."""
+    lo = hi = None
+    for name in topics:
+        t = timestamps_for(name)
+        lo = t[0] if lo is None else min(lo, t[0])
+        hi = t[-1] if hi is None else max(hi, t[-1])
+    return lo, hi
+
+# hold the first and last real pose at the global start and end
+if t_lo < odom_ts[0]:
+    log_tf("base", ts_ns(t_lo), pose_pos[0], pose_orien[0])
+...
+if t_hi > odom_ts[-1]:
+    log_tf("base", ts_ns(t_hi), pose_pos[-1], pose_orien[-1])
+```
+
+The stream that starts earliest or ends latest is not the same sensor across
+missions, so re-run this per episode rather than hardcoding it.
+
+### 3.5 Merging bags: topic collisions and `frame_id` collisions are two bugs
+
+When two bags from the same rig are merged (for example a stationary ground-truth
+station plus the robot), you can hit both:
+
+1. **Topic collision.** Both write `/camera/color/*` and `/rslidar_points`, and a
+   naive merge interleaves them into one channel, producing an erratic jumping
+   pose track. Fix: prefix every topic per source (`/grs`, `/robot`).
+2. **`frame_id` collision.** The same two sensors also share `frame_id` strings.
+   Topic prefixing does not fix this, because `frame_id` lives inside each
+   message's `Header`. Left unfixed, a stationary sensor and a moving one
+   silently resolve to the same tf frame.
+
+Detect collisions by peeking one message per connection, which is enough to see
+its `frame_id` values:
+
+```python
+def detect_frame_collision(reader, src_store, colliding_frames):
+    for conn in reader.connections:
+        for _, _, data in reader.messages(connections=[conn]):
+            msgtype = resolve_msgtype(conn.msgtype)       # see MCAP-AUTHORING.md#33
+            msg = src_store.deserialize_ros1(data, msgtype)
+            frame_ids = set()
+            if hasattr(msg, "header") and hasattr(msg.header, "frame_id"):
+                frame_ids.add(msg.header.frame_id)
+            elif msgtype.endswith("TFMessage"):
+                for tr in msg.transforms:
+                    frame_ids.add(tr.header.frame_id)
+                    frame_ids.add(tr.child_frame_id)
+            if frame_ids & colliding_frames:
+                return True
+            break        # one message per connection is enough
+    return False
+
+def remap_frame_ids(msg, msgtype, remap):
+    if hasattr(msg, "header") and hasattr(msg.header, "frame_id"):
+        if msg.header.frame_id in remap:
+            msg.header.frame_id = remap[msg.header.frame_id]
+    elif msgtype.endswith("TFMessage"):
+        for tr in msg.transforms:
+            if tr.header.frame_id in remap:
+                tr.header.frame_id = remap[tr.header.frame_id]
+            if tr.child_frame_id in remap:
+                tr.child_frame_id = remap[tr.child_frame_id]
+    return msg
+```
+
+Rename only the specific colliding names. Leave `base_link`, `odom`, `map`, and
+`camera_link` alone, since blanket renaming breaks the real chains.
+
+### 3.6 Flattening non-physical pose noise
+
+Symptom: two lidars that should sit on the same floor plane render tilted or
+offset relative to each other, and the offset changes whenever the pose updates.
+
+The case that produced this fix: a wheeled ground robot's `/tf` carried
+`odom→base_link` and `map→odom` with roll and pitch standard deviation of 1–6°
+per scene, peaks up to ±60°, and z swinging over a meter within one episode, all
+physically impossible on a flat floor. Cross-checking the same bag's `/amcl_pose`
+showed exactly `roll=pitch=z=0.0` on every message, since AMCL only estimates 2D
+pose. Some other 3D pose-fusion node was writing the noisy values, and that noise
+sat on the only path from the robot's sensors up to the `map` frame.
+
+Flatten only the pairs that carry the noise, keeping x, y, and yaw:
+
+```python
+import math
+
+PLANAR_TF_PAIRS = {("odom", "base_link"), ("map", "odom")}
+
+def quat_from_rpy(roll, pitch, yaw):
+    cr, sr = math.cos(roll / 2), math.sin(roll / 2)
+    cp, sp = math.cos(pitch / 2), math.sin(pitch / 2)
+    cy, sy = math.cos(yaw / 2), math.sin(yaw / 2)
+    return (sr * cp * cy - cr * sp * sy,
+            cr * sp * cy + sr * cp * sy,
+            cr * cp * sy - sr * sp * cy,
+            cr * cp * cy + sr * sp * sy)       # x, y, z, w
+
+def _yaw_from_quat(q):
+    return math.atan2(2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y * q.y + q.z * q.z))
+
+def flatten_planar_transforms(msg, msgtype, pairs=PLANAR_TF_PAIRS):
+    """Force listed (parent, child) transforms to pure 2D: keep x/y and yaw,
+    zero z, discard roll/pitch. No-op for every other message type or pair."""
+    if not msgtype.endswith("TFMessage"):
+        return msg
+    for tr in msg.transforms:
+        if (tr.header.frame_id, tr.child_frame_id) not in pairs:
+            continue
+        qx, qy, qz, qw = quat_from_rpy(0.0, 0.0, _yaw_from_quat(tr.transform.rotation))
+        tr.transform.rotation.x, tr.transform.rotation.y = qx, qy
+        tr.transform.rotation.z, tr.transform.rotation.w = qz, qw
+        tr.transform.translation.z = 0.0
+    return msg
+```
+
+Before applying this, verify the transforms you are not touching are real:
+constant static mounts and genuine wheel-joint rotation should be left alone.
+
+### 3.7 Frames that cannot be connected, and conventions that bite
+
+Recognize and document these, don't patch them:
+
+- No `CameraInfo` or `CameraCalibration` anywhere means no camera frustum.
+- No recorded extrinsics means per-sensor point clouds cannot be registered
+  against each other, except any the robot's own stack pre-fused.
+- A `header.frame_id` that appears in no transform anywhere (one camera's
+  `..._optical` frame was absent from both `/tf` and `/tf_static` in the entire
+  source) cannot be bridged without inventing a calibration.
+
+Conventions that cost real time:
+
+| Trap | What was wrong | Correct handling |
+|---|---|---|
+| A devkit applies `world_point = Rz(yaw) @ (p + offset)` | A TF parent→child is `R @ p + t`, so `t = R @ offset`, not `offset` | Expand the devkit's own expression algebraically before turning it into a transform |
+| Paper and launch file specify a 15° downward lidar tilt | The raw cloud's floor was already flat in its own frame, and re-applying 15° sloped it by about 2 m across the room | Went with the sensor data and flagged the discrepancy rather than silently overriding it |
+| A devkit's transform helper names its variables backwards, setting `child = attrs["base_frame_id"]` | Verified `base_frame_id` is always the physical parent, since the tree root never appears as a child | Trust the plain keys, not the helper's variable names, and re-derive the composition yourself |
+| A devkit's box-heading helper reads `center3D` where it means `rotation3D` | Genuine devkit bug | Read `rotation3D.z` directly |
+| Devkit comments say sequence A uses calibration `param_a` | Its shipped files actually matched `param_b`, and two sequences differed by several degrees of boresight | Parse calibration fresh from each sequence's own shipped files |
+| Raw quaternion arrays | Stored as `[x, y, z, w]`, not `[w, x, y, z]`. Verified by checking that the devkit feeds them straight into `scipy.Rotation.from_quat()` with no reordering | Check the devkit's own usage before assuming an order |
+| A payload mounted 180° flipped about X relative to the robot base | A genuine calibrated fact, not a bug: the quaternion is exactly `w≈0, x≈-1` | Sanity-check by transforming a real scan and confirming points land below the base, not above |
+| Camera orientation columns are Omega/Phi/Kappa | Photogrammetric convention `M = Rz(κ)·Ry(φ)·Rx(ω)` maps ground (ENU) to camera, so `world_from_camera = M.T` | Confirm by checking `M.T`'s local-X column against real heading |
+| Optical-frame convention | ROS camera drivers use a fixed `rpy = (-90°, 0, -90°)` from `camera_link` to `*_optical_frame`. Universal, not robot-specific | Author it when the bag omits it |
+| Calibration files giving `roll/pitch/yaw` | ROS `tf2::Quaternion::setRPY` is intrinsic ZYX | Use the matching conversion below |
+
+```python
+import numpy as np
+from foxglove.messages import Quaternion
+
+def rpy_to_quat(roll, pitch, yaw):
+    """Intrinsic ZYX (yaw-pitch-roll), matching ROS tf2 Quaternion::setRPY."""
+    cr, sr = np.cos(roll / 2.0), np.sin(roll / 2.0)
+    cp, sp = np.cos(pitch / 2.0), np.sin(pitch / 2.0)
+    cy, sy = np.cos(yaw / 2.0), np.sin(yaw / 2.0)
+    return Quaternion(
+        w=float(cr * cp * cy + sr * sp * sy),
+        x=float(sr * cp * cy - cr * sp * sy),
+        y=float(cr * sp * cy + sr * cp * sy),
+        z=float(cr * cp * sy - sr * sp * cy),
+    )
+```
+
+XML calibration files often declare a default namespace, which makes every tag
+namespace-qualified and breaks `ElementTree.find()` with plain tag names:
+
+```python
+import xml.etree.ElementTree as ET
+
+def parse_xml_strip_ns(path):
+    tree = ET.parse(path)
+    for el in tree.getroot().iter():
+        if "}" in el.tag:
+            el.tag = el.tag.split("}", 1)[1]
+    return tree.getroot()
+```
+
+**Verify calibration numerically, never against the paper alone.** Papers and
+devkits have been wrong or self-contradictory across multiple real imports.
+Cheap checks that caught real bugs: lidar z-spread before/after a boresight (31 m
+to 12.7 m, confirming gravity-alignment of a tilted scanner); a rotation
+matrix's local-X column against heading from consecutive position deltas
+(agreeing to about 1°); a derived IMU position holding a constant lever arm from
+the camera across a whole sequence; a z-histogram of a real scan clustering
+below the robot, not above; projecting the lidar into the camera and checking
+points land on real scene geometry.
+
+---
+
+## 4. Point clouds
+
+### 4.1 Large ROS2-CDR `PointCloud2` can freeze the App; `foxglove.PointCloud` does not
+
+Isolated over four rounds of otherwise-correct byte-level fixes, with
+side-by-side testing on the same episode. The episode loaded fine without the
+topic, and a different dataset ships `foxglove.PointCloud` messages up to 30.6 MB
+with no issue, 4x larger than the ROS2-CDR `PointCloud2` attempt that froze the
+App every time. So this is not about message size. The ROS2-CDR `PointCloud2`
+decode path has a scaling problem the Foxglove-protobuf `PointCloud` path does
+not.
+
+Rule: author any large or accumulated cloud as `foxglove.PointCloud`. Ordinary
+per-scan ROS `PointCloud2` topics work fine at their own much smaller per-message
+size, so leave those alone.
+
+To add a Foxglove-schema topic to an existing ROS 2 MCAP, note that
+`foxglove-sdk`'s writer is a compiled extension with no "serialize this message
+to bytes" API. Author into a throwaway mini-MCAP, then splice the bytes:
+
+```python
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import foxglove
+from foxglove.channels import PointCloudChannel
+from foxglove.messages import (
+    PackedElementField, PackedElementFieldNumericType, PointCloud, Timestamp,
+)
+from mcap.reader import make_reader
+
+def author_mini_mcap(topic, frame_id, snapshots):
+    """snapshots: list of (t_ns, xyz float32 array). Returns a temp .mcap path."""
+    f32 = PackedElementFieldNumericType.Float32
+    fields = [PackedElementField(name=n, offset=4 * i, type=f32)
+              for i, n in enumerate(("x", "y", "z"))]
+    tmp_path = Path(tempfile.mkstemp(suffix=".mcap")[1])
+    tmp_path.unlink()                    # open_mcap requires the path not to exist
+    ch = PointCloudChannel(topic=topic)
+    with foxglove.open_mcap(str(tmp_path)):
+        for t_ns, xyz in snapshots:
+            sec, nsec = divmod(t_ns, 1_000_000_000)
+            ch.log(
+                PointCloud(
+                    timestamp=Timestamp(sec=int(sec), nsec=int(nsec)),
+                    frame_id=frame_id, point_stride=12, fields=fields,
+                    data=np.ascontiguousarray(xyz, dtype=np.float32).tobytes(),
+                ),
+                log_time=t_ns,
+            )
+    return tmp_path
+
+def read_spliceable(mini_path, topic):
+    """Returns (schema, channel, [(log_time, data, publish_time), ...])."""
+    with open(mini_path, "rb") as f:
+        reader = make_reader(f)
+        summary = reader.get_summary()
+        schema = next(s for s in summary.schemas.values() if s.name == "foxglove.PointCloud")
+        channel = next(c for c in summary.channels.values() if c.topic == topic)
+        f.seek(0)
+        msgs = [(m.log_time, m.data, m.publish_time)
+                for _s, c, m in reader.iter_messages() if c.id == channel.id]
+    return schema, channel, msgs
+```
+
+Then register that schema and channel on the output writer and interleave the
+messages by `log_time` using the patch tool in
+[MCAP-AUTHORING.md](MCAP-AUTHORING.md#appendix-b-complete-mcap-patch-tool).
+
+### 4.2 Skip zero-point scans instead of logging an empty message
+
+A 0-point cloud is spec-valid (correct `point_stride`, `fields`, `frame_id`,
+0-byte `data`) and decodes fine at the MCAP layer, but the 3D tile shows
+`Failed to load: <topic>` on those frames. Some sensors are silent a lot: one
+dataset's rear low-resolution lidar returned 0 points on 74 of 79 scans in one
+scene, and up to about 95 % in others, while the front unit was never empty.
+
+```python
+if pts.shape[0] == 0:
+    continue          # sensor silence stays silence: no message, no fake points
+```
+
+After the fix, zero-length messages on that topic went from 74 to 0, with the 5
+real non-empty scans preserved.
+
+A related but different case: a lidar that emits zero-return placeholder points
+at the origin. Those are real messages with junk points, so filter by range
+rather than dropping the message:
+
+```python
+mask = np.linalg.norm(pts[:, :3], axis=1) > 0.5     # metres
+pts = pts[mask]
+```
+
+### 4.3 Colour fields, stride, and packing
+
+**Colour fields** are `r`/`red`, `g`/`green`, `b`/`blue`, `a`/`alpha`, or a packed
+`color`/`rgb`/`rgba`. Integer types are normalised by their own maximum, so
+`uint8` 0–255 is right. A float field is divided by 255 only when a value exceeds
+2, which makes float colour ambiguous. Use `uint8`.
+
+**Mixed numeric types in one cloud work**, and a numpy structured dtype is the
+reliable way to build the buffer. Getting `point_stride` wrong silently
+misaligns every field:
+
+```python
+F32 = PackedElementFieldNumericType.Float32
+U8 = PackedElementFieldNumericType.Uint8
+
+POINT_STRIDE = 20                     # x,y,z,intensity float32 then r,g,b,a uint8
+POINT_FIELDS = [
+    PackedElementField(name=n, offset=o, type=F32)
+    for n, o in (("x", 0), ("y", 4), ("z", 8), ("intensity", 12))
+] + [
+    PackedElementField(name=n, offset=o, type=U8)
+    for n, o in (("red", 16), ("green", 17), ("blue", 18), ("alpha", 19))
+]
+
+def pack_points(pts, colors):
+    """(N,4) float32 xyz+intensity and (N,4) uint8 rgba -> 20-byte records."""
+    buf = np.empty((len(pts), POINT_STRIDE), dtype=np.uint8)
+    buf[:, :16] = np.ascontiguousarray(pts).view(np.uint8).reshape(len(pts), 16)
+    buf[:, 16:] = colors
+    return buf.tobytes()
+```
+
+**Watch alignment when mixing widths.** A layout of `x,y,z` (float32) plus
+`r,g,b` (uint8 at offsets 12, 13, 14) plus four float32 fields starting at offset
+16, stride 32, leaves a deliberate one-byte gap at offset 15 so the float32 block
+stays 4-byte aligned.
+
+**Undeclared padding is common in source data.** One dataset's lidar declared
+`point_step = 32` while its own `PointField` list (x, y, z, intensity at 4 bytes
+each) spanned only 16, wasting 16 bytes per point. Repacking to a tight stride is
+a no-op on already-tight messages, so it can run unconditionally:
+
+```python
+# sensor_msgs/msg/PointField.datatype -> byte width (stable ROS constants)
+POINTFIELD_SIZES = {1: 1, 2: 1, 3: 2, 4: 2, 5: 4, 6: 4, 7: 4, 8: 8}
+
+def repack_pointcloud2(dst_store, msg):
+    """Rebuild a PointCloud2 using only its own declared fields, tightly packed."""
+    n_pts = msg.width * msg.height
+    old_step = msg.point_step
+    raw = np.frombuffer(bytes(msg.data), dtype=np.uint8).reshape(n_pts, old_step)
+
+    chunks, new_fields, offset = [], [], 0
+    for fld in msg.fields:
+        size = POINTFIELD_SIZES[fld.datatype] * max(fld.count, 1)
+        chunks.append(raw[:, fld.offset:fld.offset + size])
+        new_fields.append(fld.__class__(name=fld.name, offset=offset,
+                                        datatype=fld.datatype, count=fld.count))
+        offset += size
+    if offset == old_step:
+        return msg                                   # already tight
+
+    PointCloud2 = dst_store.types["sensor_msgs/msg/PointCloud2"]
+    return PointCloud2(
+        header=msg.header, height=msg.height, width=msg.width, fields=new_fields,
+        is_bigendian=msg.is_bigendian, point_step=offset,
+        row_step=offset * msg.width,
+        data=np.ascontiguousarray(np.concatenate(chunks, axis=1)).reshape(-1),
+        is_dense=msg.is_dense,
+    )
+```
+
+Honest accounting of that win: uncompressed bytes halved, but measured on-disk
+saving across 7 episodes was only 5.2 % (31.5 GB down to 29.8 GB), because 12 of
+the 16 wasted bytes were near-always zero and already squashed by MCAP's chunk
+compression. The defensible win is roughly 50 % less per-message CPU decode cost
+on the largest channel. Don't oversell padding fixes as file-size fixes.
+
+**Downcast only when provably lossless.** One dataset packs intensity as `uint8`
+(19 down to 16 byte stride) after verifying intensity is always an exact integer
+in `[0, 255]` on real scans, and asserts it per scan so a future sequence raises
+loudly instead of silently clipping:
+
+```python
+raw_intensity = xyzi[:, 3]
+if n and (np.any(raw_intensity != np.round(raw_intensity))
+          or raw_intensity.min() < 0 or raw_intensity.max() > 255):
+    raise ValueError(f"{path}: intensity not representable as uint8 losslessly")
+```
+
+**PCL "packed float rgb"** must be unpacked into separate `uint8` fields:
+
+```python
+packed = pc.numpy(("rgb",)).ravel().astype(np.float32).view(np.uint32)
+red   = (packed >> 16) & 0xFF
+green = (packed >> 8) & 0xFF
+blue  = packed & 0xFF
+```
+
+Point clouds need at least two of `x`/`y`/`z`.
+
+### 4.4 Coloring point clouds with real color
+
+Project each point into the nearest-in-time image through the calibrated
+lidar-to-camera transform and sample the image. Rules that kept it honest:
+
+- sample from the full-resolution source image even when the embedded image topic
+  is downsampled for display (see [§5.8](#58-transcoding-raw-images-and-when-not-to));
+- points with no valid projection fall back to greyscale-from-intensity, never a
+  fabricated color;
+- validate before running at scale. Render one scan's projected points colored by
+  depth, overlaid on the image, and check that they land on real geometry.
+
+```python
+# rgb starts as greyscale-from-intensity, then valid projections overwrite it
+intensity_norm = np.clip(raw_intensity / max(float(raw_intensity.max()), 1.0), 0, 1)
+grey = (intensity_norm * 200 + 40).astype(np.uint8)      # avoid pure black
+rgb = np.stack([grey, grey, grey], axis=1)
+rgb[valid] = image_array[row_i[valid], col_i[valid]]
+```
+
+For a multi-camera rig, let the first camera that sees a point win, and leave
+uncovered points grey:
+
+```python
+colored = np.zeros(len(points), dtype=bool)
+for cam in cameras:
+    u, v, orig_idx = project(points, cam)
+    new = ~colored[orig_idx]
+    rgb[orig_idx[new]] = cam.image[v[new], u[new]]
+    colored[orig_idx[new]] = True
+```
+
+Read the colours back out of the written MCAP and re-project them to prove the
+packing and field offsets are right. A byte-for-byte comparison of decoded x/y/z
+against the raw source, before and after adding RGB fields, is what proved
+colorization never touched a coordinate.
+
+### 4.5 Semantic and label coloring
+
+Share one `class → color` map across every tile (radar points, camera 2D boxes,
+lidar 3D boxes) so a class reads identically everywhere.
+
+A real bug lived here for a while: box geometry was correct 1:1 against the
+source JSON, verified by counting boxes per scan, but the class-name field was
+never read, so every box rendered identical plain green. Geometry being right is
+not evidence the labels are right, so check both.
+
+### 4.6 Accumulated "map" topics, and how they blow up file size
+
+They exist because a single-scan topic flickers hard: each message fully replaces
+the last, points-per-scan can swing 5x scan to scan, and pose often updates slower
+than the lidar. An accumulated topic shows everything seen up to the current
+playback time.
+
+Voxel-hash all points, take each voxel's first chronological occurrence, and sort
+by index. Then `map_points[:k]` is exactly "the map as of the k-th new voxel", and
+producing the message at any time is a binary search rather than a rebuild:
+
+```python
+voxel_idx = np.floor(all_xyz / voxel_size).astype(np.int64)
+keys = voxel_idx[:,0]*73856093 ^ voxel_idx[:,1]*19349663 ^ voxel_idx[:,2]*83492791
+_, first_idx = np.unique(keys, return_index=True)
+first_idx = np.sort(first_idx)            # k-th NEW voxel, in order of appearance
+map_points, map_time = all_xyz[first_idx], all_time[first_idx]
+
+for t_ns in output_times:
+    count = int(np.searchsorted(map_time, t_ns, side="right"))   # O(log n)
+    if count == 0:
+        continue
+    map_ch.log(PointCloud(..., data=map_points[:count].tobytes()), log_time=t_ns)
+```
+
+Output size scales as `n_messages × final_voxel_count`, and both factors scale
+with route length and duration rather than point count. One sequence's tuned
+`(0.2 m, 2 Hz)` settings, reused unchanged on an 11x-longer sequence, produced a
+201 GB file before anyone checked: 13x bigger final map times 6.7x more messages
+is roughly 87x. The longer sequence ended up at `(0.75 m, 0.5 Hz)`.
+
+Run this dry-run estimate before committing to settings for any new episode:
+
+```python
+BYTES_PER_POINT = 16          # your point stride
+
+for voxel in (0.2, 0.5, 0.75, 1.0):
+    idx = np.floor(all_xyz / voxel).astype(np.int64)
+    keys = idx[:,0]*73856093 ^ idx[:,1]*19349663 ^ idx[:,2]*83492791
+    n_vox = len(np.unique(keys))
+    for hz in (0.5, 1.0, 2.0):
+        n_msgs = int(duration_s * hz)
+        print(voxel, hz, f"{n_vox * n_msgs * BYTES_PER_POINT / 1e9:.1f} GB (upper bound)")
+```
+
+It is an upper bound, since early messages carry fewer voxels, but it is the
+number that would have caught the 201 GB file.
+
+Policy that came out of it: voxel size and update rate are a required per-episode
+pair, never a shared constant, and bias toward larger voxels and lower rate. The
+topic carries zero unique information, since the raw per-scan topic already has
+every point, and it was about 55 % of one episode's total file size. See
+[MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#size-buffering-speed-and-cost)
+for how this ranks against other size drivers.
+
+---
+
+## 5. Images, cameras, video, and calibration
+
+### 5.1 `CameraInfo` field casing (silent frustum failure)
+
+ROS 1's `CameraInfo` message definition uses uppercase `D/K/R/P`; ROS 2 renamed
+them to lowercase. It is a pure rename, with identical types, order, and count.
+Carried through verbatim from a ROS 1 bag into a schema declared
+`sensor_msgs/msg/CameraInfo`, the frustum code finds the canonical lowercase
+fields undefined and marks the channel `Failed to load`.
+
+```python
+from rosbags.typesys import Stores, get_typestore
+
+foxy = get_typestore(Stores.ROS2_FOXY)
+camerainfo_def = {"sensor_msgs/msg/CameraInfo": foxy.FIELDDEFS["sensor_msgs/msg/CameraInfo"]}
+src_store.register(dict(camerainfo_def))
+dst_store.register(dict(camerainfo_def))
+```
+
+When registering the bag's own types, drop `CameraInfo` first so the bag's
+uppercase definition cannot overwrite the canonical one:
+
+```python
+from rosbags.convert.converter import get_types_from_msg
+
+typs = get_types_from_msg(conn.msgdef, conn.msgtype)
+typs.pop("sensor_msgs/msg/CameraInfo", None)
+src_store.register(dict(typs))
+```
+
+`CameraInfo` was the only type across four scene bags whose casing differed from
+ROS 2 in one import, so a general case-folding pass is not warranted by default —
+but do check for it. See [MCAP-AUTHORING.md §3.2](MCAP-AUTHORING.md#32-ros-1-to-ros-2-cdr-by-hand-two-typestores-always)
+for how this fits into a full bag conversion.
+
+### 5.2 Pair every image topic with its calibration
+
+An image stream and a `CameraCalibration` topic are not associated by name. Set
+the channel metadata explicitly, or the Image tile has nothing to project
+against and the 3D tile cannot draw the frustum:
+
+```python
+channel = CompressedImageChannel(
+    topic="/camera/left/image_raw",
+    metadata={"mcap.calibration_topic": "/camera/left/calibration"},
+)
+```
+
+The same key works for `RawImageChannel` and `CompressedVideoChannel`. Publish
+the calibration once per episode for a static rig:
+
+```python
+from foxglove.channels import CameraCalibrationChannel
+from foxglove.messages import CameraCalibration
+
+calib_ch = CameraCalibrationChannel(topic="/camera/left/calibration")
+calib_ch.log(
+    CameraCalibration(
+        timestamp=ts(t0_ns), frame_id="camera_left", width=1920, height=1456,
+        distortion_model="plumb_bob",       # see §5.6 for fisheye
+        D=[k1, k2, p1, p2, 0.0],
+        K=K.flatten().tolist(),             # 3x3 row-major
+        R=np.eye(3).flatten().tolist(),     # identity, see §5.4
+        P=P[:3, :4].flatten().tolist(),     # 3x4 row-major
+    ),
+    log_time=t0_ns,
+)
+```
+
+### 5.3 Topic names decide the camera geometry
+
+With geometry on Auto, the viewer builds two models from one `CameraCalibration`,
+`K`+`D` (original, distorted) and `P` (rectified), and picks silently only when
+the two agree to within `min(1, max(0.5, diagonal × 1e-4))` px, which is 0.5 px at
+1920×1456. Cameras with `k1 = -0.14` put the models 91 px apart, so Auto refuses
+and nothing projects, with the message `Original and rectified camera models
+differ; choose the image geometry`.
+
+The tiebreaker is the topic's **last path segment**, scanned backwards while
+skipping segments beginning with `compressed`. It must contain the token `image`,
+plus `raw` for the original or `rect`/`rectified` for the rectified image. So
+`/camera/left/image_raw`, not `/camera/left`.
+
+A calibration with `D` all zeros and `P` built from `K` needs no hint, because
+the two models coincide and Auto resolves it.
+
+### 5.4 Calibration `R` and double rotation
+
+If the rectified frame is itself a real frame in the transform tree, set the
+calibration's `R` to identity. Otherwise `R` repeats a rotation the tree already
+applies and the projection lands in the wrong place.
+
+Rectification is a pure rotation plus a new pinhole `K_rect`, so rectified
+products (depth, semantic, flow) belong in their own frame rather than stacked on
+the raw camera's frame. See [§3](#3-frames-and-transforms) for the transform tree
+itself.
+
+### 5.5 Depth and other non-RGB image data
+
+- **Depth encoding matters.** `mono16` displays but carries no metric value. Use
+  `16uc1` for millimetres or `32fc1` for metres. `16uc1` saturates at 65.5 m, so
+  ground truth reaching 102 m has to go out as `32fc1`.
+- **A raw 16-bit depth PNG through `CompressedImage` displays as solid black.** A
+  700 mm value is about 1 % brightness as linear 16-bit grey, and no depth-aware
+  normalisation is applied. Pre-colorize with a fixed range and colormap:
+
+  ```python
+  import io
+  import matplotlib
+  import numpy as np
+  from PIL import Image
+
+  VIRIDIS = (matplotlib.colormaps["viridis"](np.linspace(0, 1, 256))[:, :3] * 255).astype(np.uint8)
+
+  def colorize_depth_png(path, vmax_m=6.0):
+      depth_mm = np.array(Image.open(path), dtype=np.uint16)
+      valid = depth_mm > 0
+      idx = np.clip((depth_mm.astype(np.float32) / 1000.0) / vmax_m, 0.0, 1.0)
+      rgb = VIRIDIS[(idx * 255).astype(np.uint8)]
+      rgb[~valid] = 0                       # invalid/zero return -> black
+      buf = io.BytesIO()
+      Image.fromarray(rgb, mode="RGB").save(buf, format="PNG")
+      return buf.getvalue()
+  ```
+
+- **Radar and sonar:** render polar to cartesian and log as `mono8` `RawImage`
+  with `step = width`. For sonar, run `np.nan_to_num` first. Logging both the
+  polar and the cartesian BEV image is useful, since the polar image is the raw
+  measurement.
+- **Doppler correction can be era-dependent.** One dataset applies radar Doppler
+  and offset correction only to post-upgrade recordings, because in pre-upgrade
+  files the corresponding column is a validity mask and applying the correction
+  corrupts the image. Gate on the frame timestamp.
+- **Segmentation:** map class indices through a palette to an RGB PNG, with
+  anything unlabelled going to black.
+- **Audio:** `RawAudio` with `format="pcm-s16"` read straight from WAV worked in hands-on testing,
+  though `foxglove.RawAudio` isn't in the official supported-schemas list, so verify playback in
+  the App before relying on it.
+
+### 5.6 Distortion models
+
+Source `camera_info.distortion_model` values are ROS-style. Foxglove's
+`CameraCalibration.distortion_model` does not recognize `equidistant`, so map it
+to `kannala_brandt`, the general fisheye model that `equidistant` is a special
+case of, with the same 4-parameter `D`. `plumb_bob` passes through unchanged.
+
+```python
+DISTORTION_MODEL_MAP = {"equidistant": "kannala_brandt", "plumb_bob": "plumb_bob"}
+```
+
+On the OpenCV side, projecting points for a `equidistant`/`kannala_brandt` camera
+means `cv2.fisheye.projectPoints`, not `cv2.projectPoints`.
+
+Open issue worth knowing: the 3D tile's Auto rectified-projection detection
+rejects `kannala_brandt` with `Rectified projection is available, but Auto cannot
+prove the image uses it: Unsupported distortion model 'kannala_brandt'`. The
+calibration itself is valid, since frustums render. The workaround is to
+precompute the lidar-to-image projection and log it as an `ImageAnnotations`
+overlay, which is decoded independently of the calibration-driven live
+projection:
+
+- one overlay topic per camera, for example `/cam/hdr_front/lidar_overlay`;
+- select it as the image's annotation source in the Image tile's settings, since
+  it is not auto-paired by name;
+- cap the points per (scan, camera) pair, for example 600 via a seeded random
+  subsample. Logging thousands of individual `Point2` and `Color` objects
+  balloons both build time and file size for no visible benefit at typical zoom;
+- color by depth with a fixed `vmax`, and verify by compositing the decoded
+  overlay onto the decoded RGB frame in Python rather than trusting message
+  counts.
+
+### 5.7 Video
+
+The viewer decodes `CompressedVideo` through WebCodecs, and the constraints come
+from that decode path rather than from quality goals. All four were found the
+hard way, each presenting as no video at all:
+
+| Constraint | Why |
+|---|---|
+| H.264 only | HEVC is not accepted |
+| `-bf 0` | Streams containing B-frames are rejected outright |
+| `libx264`, not `h264_nvenc` | NVENC output passes `VideoDecoder.isConfigSupported` and then never emits a frame. Verified against Chromium 144, where an NVENC stream decoded 0 of 30 frames while a libx264 stream at identical profile and level decoded 30 of 30 |
+| `-bsf:v dump_extra=freq=keyframe` | Repeats SPS/PPS on every keyframe, so playback can start from any seek point rather than only frame 0 |
+
+```python
+def transcode_h264(mp4_path, out_path, stride, gop):
+    """Transcode every stride-th frame of a source video to an Annex-B H.264 stream."""
+    cmd = [
+        "ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", mp4_path,
+        "-vf", f"select=not(mod(n\\,{stride}))", "-vsync", "0",
+        "-c:v", "libx264", "-preset", "veryfast", "-crf", "26", "-g", str(gop),
+        "-bf", "0", "-pix_fmt", "yuv420p",
+        "-bsf:v", "dump_extra=freq=keyframe", "-f", "h264", out_path,
+    ]
+    subprocess.run(cmd, check=True)
+    return out_path
+
+def annexb_packets(path):
+    """One access unit per message is what the viewer expects."""
+    import av
+    with av.open(path) as container:
+        stream = container.streams.video[0]
+        return [bytes(p) for p in container.demux(stream) if p.size]
+
+channel = CompressedVideoChannel(
+    topic="/camera/left/image_raw",
+    metadata={"mcap.calibration_topic": "/camera/left/calibration"},
+)
+for i, packet in enumerate(packets):
+    t_ns = epoch_ns + int(times[i] * 1e9)
+    channel.log(
+        CompressedVideo(timestamp=ts(t_ns), frame_id="camera_left",
+                        format="h264", data=packet),
+        log_time=t_ns,
+    )
+```
+
+The same three encoder rules apply when generating frames yourself, feeding raw
+BGR on ffmpeg's stdin with `-f rawvideo -pix_fmt bgr24 -s WxH`.
+
+If a video stream is paired with a calibration topic, do not downscale it. The
+calibration would then describe an image size that no longer exists.
+
+Two lessons from encoding a sparse derived stream (optical flow rendered as a
+colour wheel over mostly-black frames):
+
+| Question | Answer |
+|---|---|
+| How to make a sparse field compress | Dilating the field is worth far more than lowering quality. At 1920×1456, a 5 px kernel at CRF 22 gave 411 KB/frame and a 9 px kernel at CRF 26 gave 107 KB, while raising CRF alone only reached 260 KB. Isolated lit pixels on black are the worst case for an inter-frame codec, and the denser render also reads better |
+| Where to set the brightness normaliser | Fixed per episode, at the 75th percentile of magnitude. Per-frame normalising stretches a stationary stretch back up to full scale and makes standing still look like motion |
+
+### 5.8 Transcoding raw images, and when not to
+
+Raw `rgb8`/`bgr8` `Image` topics were about 76 % of one scene's uncompressed
+bytes with no codec at all, and were the main reason client-side buffering of an
+episode was slow. Transcoding them to JPEG-backed
+`sensor_msgs/msg/CompressedImage` at quality 90 cut that roughly 10x with no
+viewer changes needed.
+
+Detect eligibility by encoding rather than topic name, so it generalizes across
+scenes and platforms:
+
+```python
+JPEG_ENCODINGS = {"rgb8", "bgr8"}
+
+def detect_jpeg_topics(reader, src_store, prefix):
+    """dst_topic set for Image connections carrying a JPEG-eligible encoding."""
+    jpeg_topics = set()
+    for conn in reader.connections:
+        if resolve_msgtype(conn.msgtype) != "sensor_msgs/msg/Image":
+            continue
+        dst_topic = f"{prefix}{conn.topic}"
+        if dst_topic in jpeg_topics:
+            continue
+        for _, _, data in reader.messages(connections=[conn]):
+            msg = src_store.deserialize_ros1(data, "sensor_msgs/msg/Image")
+            if msg.encoding in JPEG_ENCODINGS:
+                jpeg_topics.add(dst_topic)
+            break
+    return jpeg_topics
+
+def image_to_compressed(dst_store, msg, quality=90):
+    import io
+    from PIL import Image as PILImage
+    row_bytes = msg.width * 3
+    frame = np.frombuffer(bytes(msg.data), dtype=np.uint8).reshape(msg.height, msg.step)
+    frame = frame[:, :row_bytes].reshape(msg.height, msg.width, 3)
+    if msg.encoding == "bgr8":
+        frame = frame[:, :, ::-1]
+    buf = io.BytesIO()
+    PILImage.fromarray(frame, mode="RGB").save(buf, format="JPEG", quality=quality)
+    CompressedImage = dst_store.types["sensor_msgs/msg/CompressedImage"]
+    # rosbags' CDR serializer calls .view() on sequence-of-primitive fields, so
+    # they must be numpy arrays, not bytes.
+    jpeg_bytes = np.frombuffer(buf.getvalue(), dtype=np.uint8)
+    return CompressedImage(header=msg.header, format="jpeg", data=jpeg_bytes)
+```
+
+Remaining rules:
+
+- **Never JPEG depth.** `16UC1`, `32FC1`, and anything that isn't 8-bit
+  3-channel stays raw, because JPEG is 8-bit and lossy.
+- **Register the channel with the output type.** If you transcode `Image` to
+  `CompressedImage`, the channel's schema must be `CompressedImage`.
+- **Downsample for display where the full-resolution copy isn't needed for
+  math.** Embedding 8000×4000 panoramas at 0.5 scale and JPEG quality 85 took one
+  frame from 4.96 MB to 0.97 MB, and a 4500-frame sequence from about 22 GB to
+  about 4.4 GB, while colorization still sampled the full-resolution file on disk.
+  Do not do this when the topic is paired with a calibration (§5.7).
+- **`CompressedImage.format` is not always a plain codec name.** One dataset's
+  topic carries `format = "rgb8; jpeg compressed bgr8"`, where the true source
+  colorspace is the last token. Custom extraction code that assumes `"jpeg"` will
+  invert colors.
+- **Strip alpha before re-encoding** if the source PNGs are RGBA.
+
+### 5.9 Overlays and annotations
+
+```python
+from foxglove.channels import ImageAnnotationsChannel, SceneUpdateChannel
+from foxglove.messages import (
+    Color, CubePrimitive, ImageAnnotations, KeyValuePair, Point2,
+    PointsAnnotation, PointsAnnotationType, SceneEntity, SceneUpdate,
+    TextAnnotation, TextPrimitive,
+)
+
+# 2D box on the image tile: LineLoop for a rectangle, LineList for a projected
+# 3D wireframe (pairs of endpoints), plus a text label.
+ann_ch.log(
+    ImageAnnotations(
+        points=[PointsAnnotation(
+            timestamp=ts(t_ns), type=PointsAnnotationType.LineLoop,
+            points=[Point2(x=p["x"], y=p["y"]) for p in corners],
+            outline_color=color, thickness=3.0,
+            metadata=[KeyValuePair(key="label", value=class_name)],
+        )],
+        texts=[TextAnnotation(
+            timestamp=ts(t_ns), position=Point2(x=x0, y=y0 - 14), text=class_name,
+            font_size=12.0, text_color=Color(r=1, g=1, b=1, a=1), background_color=color,
+        )],
+    ),
+    log_time=t_ns,
+)
+
+# 3D cuboid, with the entity id carrying a persistent track identity
+box_ch.log(
+    SceneUpdate(entities=[SceneEntity(
+        timestamp=ts(t_ns), frame_id="lidar", id=track_uuid,
+        metadata=[KeyValuePair(key="label", value=class_name)],
+        cubes=[CubePrimitive(pose=pose, size=Vector3(x=l, y=w, z=h),
+                             color=class_color(class_name, alpha=0.35))],
+        texts=[TextPrimitive(pose=label_pose, billboard=True, scale_invariant=True,
+                             font_size=14.0, text=class_name, color=color)],
+    )]),
+    log_time=t_ns,
+)
+```
+
+Details that matter:
+
+- **Entity `id` should be a persistent track ID**, so an object keeps identity
+  across frames. A source annotation UUID is ideal.
+- **Attach metadata instead of baking text pixels.** The inspector shows an
+  entity's `label` plus any `KeyValuePair` metadata when clicked.
+- **Static overlays persist.** A `SceneUpdate` entity stays visible until
+  replaced or deleted, so a full-session trajectory polyline can be logged once as
+  a `LinePrimitive` with `type=LineStrip`.
+- **A `lifetime` on a `SceneEntity`** (for example 150 ms) makes per-frame boxes
+  disappear cleanly between updates.
+- **Mirror the source devkit's own filtering.** One devkit always drops boxes
+  with zero supporting lidar points before display, and skips boxes behind the
+  camera before projecting.
+
+See also [§4.5](#45-semantic-and-label-coloring) for sharing one class-color map
+across every overlay type.
+
+---
+
+## 6. Timestamps and clock domains
+
+### 6.1 `log_time` vs `header.stamp`
+
+The viewer's shared timeline uses `log_time`, the recording or host clock.
+`header.stamp` is the sensor capture clock and can differ per topic in the same
+file.
+
+One dataset made this concrete: every message shared one `log_time` domain, but
+the stereo camera's `header.stamp` was on the host clock while the lidar and the
+ground-truth trajectories were on the sensor's own clock, about 1.7×10⁸ s apart.
+So playback was correctly synchronized out of the box, and benchmarking against
+ground truth was not. Record the offset as a sample field and say which clock
+each product uses.
+
+### 6.2 Nanoseconds since the Unix epoch, everywhere
+
+Convert centrally, in one helper, and watch the source units: microseconds,
+seconds-as-float (common for GPS time), separate `secs`/`nsecs` columns,
+nanoseconds embedded in a filename, or seconds relative to a sequence start.
+
+```python
+def ts(ns: int) -> Timestamp:
+    ns = int(ns)
+    return Timestamp(sec=ns // 1_000_000_000, nsec=ns % 1_000_000_000)
+```
+
+For a clock that counts from sequence start, rebase onto epoch nanoseconds using
+the dataset's own start-time metadata. Read a naive local timestamp as UTC so the
+same input always yields the same absolute clock; only its consistency across
+channels matters for playback:
+
+```python
+from datetime import datetime, timezone
+
+def epoch_ns_for(start_time):
+    dt = datetime.fromisoformat(start_time).replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1_000_000_000)
+```
+
+### 6.3 When no real timestamps exist
+
+One archive stored no per-scan capture time, only a sequential index. `t0` was
+parsed from the scene folder name and scans were spaced at an assumed 10 Hz. That
+is fine for smooth playback, but it must be labeled as an approximation in the
+code, the notes, and the dataset card.
+
+The same risk decided a different import's whole strategy: exploded per-frame
+files shipped with no timestamp sidecar, so authoring from them would have relied
+on nominal rates with real drift risk over a multi-minute sequence. Converting
+the original bag, which carried true per-message timestamps, was the safer path.
+
+### 6.4 Conventions differ between sequences of the same dataset
+
+In one dataset, sequence A's `.bin` filenames were GPS-time-of-week in
+nanoseconds, while sequence D's were a sequential index with the real per-scan
+time in a sibling text file. Detect rather than assume:
+
+```python
+import glob, os
+
+def load_lidar_timestamps(data_root, bin_paths):
+    """Returns a t_ns array aligned 1:1 with sorted bin_paths."""
+    sidecar = glob.glob(os.path.join(data_root, "*LidarScanTimestamp*"))
+    if sidecar:
+        with open(sidecar[0]) as f:
+            secs = [float(x) for x in f.read().split()]
+        if len(secs) != len(bin_paths):
+            raise ValueError(f"{sidecar[0]}: {len(secs)} timestamps != {len(bin_paths)} files")
+        return np.array([int(round(s * 1e9)) for s in secs], dtype=np.int64)
+    return np.array([int(os.path.splitext(os.path.basename(p))[0]) for p in bin_paths],
+                    dtype=np.int64)
+```
+
+### 6.5 Units, especially for GPS
+
+One dataset's GPS CSV stored latitude, longitude, and heading in radians (raw
+`lat=0.764, lon=-1.387` is 43.78° N, 79.47° W). `LocationFix` wants degrees for
+latitude and longitude, while `heading` is already radians and passes through.
+Getting this wrong yields an empty or nonsense Map tile with no error.
+
+```python
+latitude=float(np.degrees(float(row["latitude"]))),
+longitude=float(np.degrees(float(row["longitude"]))),
+altitude=float(row["altitude"]),
+heading=float(row["heading"]),          # already radians
+```
+
+Available columns can vary by recording era within one dataset: newer sequences
+used a `GPSTime` column and included latitude and longitude, while an older one
+used `ROSTime` and had neither. Detect and skip rather than assume.
+
+Watch for **all-zero rows instead of omitted rows**. One dataset ships a sequence
+with no GPS lock as full rows of zeros with `fix = -1`, so trusting a
+`n_gps_fixes` count produces hundreds of fixes at null island.
+
+### 6.6 Rebasing when merging sources
+
+Post-processed bags often carry `ros::Time::now()` from when the offline
+processing job ran, weeks after capture. Merged naively, the episode nominally
+spans that whole gap and cannot be scrubbed.
+
+```python
+offset = anchor_reader.start_time - other_reader.start_time
+# add `offset` to every message timestamp from the non-anchor source
+```
+
+Validate afterwards: the merged span must be close to the real recording
+duration. A single constant offset assumes the source's internal pacing matches,
+so if the merged duration is still wrong, per-message header stamps are needed.
+See [MCAP-AUTHORING.md](MCAP-AUTHORING.md#appendix-a-complete-ros-1-two-bag-merge)
+for the full merge pipeline this fits into.
+
+### 6.7 Real gaps that look like bugs but aren't
+
+- A 2633 s recording where the first real message on any of 110 topics did not
+  appear until 101.13 s in. Real recording-startup delay, so the nominal duration
+  overstated active data by about 3.5 minutes.
+- A sequence where the camera and lidar spanned the first 630 s while the IMU and
+  GPS spanned the full 1296 s. Verified real: the camera and lidar stopped while
+  the INS kept logging. Do not "fix" this by truncating IMU and GPS to match.
+- Message-rate bursts at mode transitions that existed in the original source at
+  the same timestamps, verified before and after splitting.
+- **Streams that start before the rig clock zero.** One platform's robot topics
+  began at -9.7 s. Negative timestamps have to be dropped, or the episode
+  overshoots its declared duration.
+
+This is also the explanation if you scrub to the very start of playback and a
+tile shows nothing, or "No message at or before the playhead on this topic" —
+that topic's first message may genuinely not start at `t=0`. Scrub forward
+before concluding a tile is broken; see
+[MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#tile-verification-is-a-human-step-and-it-is-not-optional).
+
+### 6.8 Assert monotonic `log_time` per channel
+
+Cheap, and it catches ordering bugs from interleaving multiple sources. The check
+is in [MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#structural-validation-of-an-authored-episode).

--- a/skills/fiftyone-dataset-import/README.md
+++ b/skills/fiftyone-dataset-import/README.md
@@ -1,6 +1,6 @@
 # Dataset Import
 
-Import any dataset into FiftyOne with automatic format detection. Supports local files, Hugging Face Hub, cloud storage, and multimodal grouped data.
+Import any dataset into FiftyOne with automatic format detection. Supports local files, Hugging Face Hub, cloud storage, multimodal grouped data, and MCAP robotics/AV sensor recordings.
 
 ## Install
 
@@ -23,9 +23,10 @@ Start the MCP server and ask your AI assistant:
 "Import the COCO dataset from /path/to/data"
 "Load the keremberke/license-plate-object-detection dataset from Hugging Face"
 "Import this folder of images, there are cameras and LiDAR files grouped by scene"
+"Import these MCAP recordings from /path/to/rosbags"
 ```
 
-The skill scans your data, auto-detects the format and media types, and loads the dataset into FiftyOne. It handles images, videos, point clouds, COCO, YOLO, VOC, KITTI, and more without you specifying the format.
+The skill scans your data, auto-detects the format and media types, and loads the dataset into FiftyOne. It handles images, videos, point clouds, MCAP multimodal recordings (robotics/AV sensor logs), COCO, YOLO, VOC, KITTI, and more without you specifying the format.
 
 ## Example
 
@@ -58,3 +59,11 @@ Or ask your assistant to open it in the App:
 
 - [Dataset Import docs](https://docs.voxel51.com/user_guide/dataset_creation/index.html)
 - [Hugging Face Hub integration](https://docs.voxel51.com/integrations/huggingface.html)
+- [FiftyOne Multimodal (MCAP) guide](https://docs.voxel51.com/user_guide/multimodal.html)
+
+This skill's directory also ships reference files the skill reads on demand rather than every
+invocation: `SPECIALIZED-3D-FORMATS.md` (PandaSet, nuScenes, Waymo, Argoverse, KITTI 3D, Lyft L5,
+A2D2), `USE-CASE-EXAMPLES.md` (copy-paste starting points), and for MCAP recordings specifically,
+`MCAP-TROUBLESHOOTING.md` (why a tile isn't rendering), `MCAP-AUTHORING.md` (authoring MCAP from
+raw sensor data, converting ROS bags, merging/patching), and `MCAP-DATASET-AND-VALIDATION.md`
+(capability flags and validating an import before calling it done).

--- a/skills/fiftyone-dataset-import/SKILL.md
+++ b/skills/fiftyone-dataset-import/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fiftyone-dataset-import
-description: Imports datasets into FiftyOne with automatic format detection. Supports all media types (images, videos, point clouds), label formats (COCO, YOLO, VOC, KITTI), multimodal grouped datasets, and Hugging Face Hub datasets. Use when importing datasets from local files or Hugging Face, loading autonomous driving data, or creating grouped datasets.
+description: Imports datasets into FiftyOne with automatic format detection. Supports all media types (images, videos, point clouds, MCAP multimodal recordings), label formats (COCO, YOLO, VOC, KITTI), multimodal grouped datasets, and Hugging Face Hub datasets. Use when importing datasets from local files or Hugging Face, loading autonomous driving data, importing robotics/AV sensor logs (MCAP, ROS bag), or creating grouped datasets.
 ---
 
 # Universal Dataset Import for FiftyOne
@@ -27,82 +27,20 @@ Look for patterns that indicate grouped data:
 - Mixed media types that should be grouped (images + point clouds)
 
 ### 4. Detect and install required packages
-Many specialized dataset formats require external Python packages. After detecting the format:
+Named autonomous-driving devkit formats (PandaSet, nuScenes, Waymo Open, Argoverse, KITTI 3D,
+Lyft L5, A2D2) need an external Python package. Check with `pip show <package>`, ask the user
+before installing, then verify with a smoke-test import. Full package table, directory-pattern
+detection, and the complete conversion workflow are in
+[SPECIALIZED-3D-FORMATS.md](SPECIALIZED-3D-FORMATS.md).
 
-1. **Identify required packages** based on the detected format
-2. **Check if packages are installed** using `pip show <package>`
-3. **Search for installation instructions** if needed (use web search or FiftyOne docs)
-4. **Ask user for permission** before installing any packages
-5. **Install required packages** (see installation methods below)
-6. **Verify installation** before proceeding
+**No package is required to import or render MCAP (`.mcap`/`.bag`/`.rrd`) files.** The file
+extension alone sets `media_type == "multimodal"`, and channel decoding and rendering happen
+client-side in the FiftyOne App. Do not tell users to `pip install mcap` for this. The only
+optional use for a Python-side package is reading channel schemas before opening the App, covered
+in Step 9D below.
 
-**Common format-to-package mappings:**
-
-| Dataset Format | Package Name | Install Command |
-|---------------|--------------|-----------------|
-| PandaSet | `pandaset` | `pip install "git+https://github.com/scaleapi/pandaset-devkit.git#subdirectory=python"` |
-| nuScenes | `nuscenes-devkit` | `pip install nuscenes-devkit` |
-| Waymo Open | `waymo-open-dataset-tf` | See Waymo docs (requires TensorFlow) |
-| Argoverse 2 | `av2` | `pip install av2` |
-| KITTI 3D | `pykitti` | `pip install pykitti` |
-| Lyft L5 | `l5kit` | `pip install l5kit` |
-| A2D2 | `a2d2` | See Audi A2D2 docs |
-
-**Additional packages for 3D processing:**
-
-| Purpose | Package Name | Install Command |
-|---------|--------------|-----------------|
-| Point cloud conversion to PCD | `open3d` | `pip install open3d` |
-| Point cloud processing | `pyntcloud` | `pip install pyntcloud` |
-| LAS/LAZ point clouds | `laspy` | `pip install laspy` |
-
-**Additional packages for Hugging Face Hub:**
-
-| Purpose | Package Name | Install Command |
-|---------|--------------|-----------------|
-| HF Hub API | `huggingface_hub` | `pip install huggingface_hub` |
-| Parquet file reading | `pyarrow` | `pip install pyarrow` |
-| Image processing | `Pillow` | `pip install Pillow` |
-
-**Installation methods (in order of preference):**
-
-1. **PyPI** - Standard pip install:
-   ```bash
-   pip install <package-name>
-   ```
-
-2. **GitHub URL** - When package is not on PyPI:
-   ```bash
-   # Standard GitHub install
-   pip install "git+https://github.com/<org>/<repo>.git"
-
-   # With subdirectory (for monorepos)
-   pip install "git+https://github.com/<org>/<repo>.git#subdirectory=python"
-
-   # Specific branch or tag
-   pip install "git+https://github.com/<org>/<repo>.git@v1.0.0"
-   ```
-
-3. **Clone and install** - For complex builds:
-   ```bash
-   git clone https://github.com/<org>/<repo>.git
-   cd <repo>
-   pip install .
-   ```
-
-**Dynamic package discovery workflow:**
-
-If the format is not in the table above:
-1. **Search PyPI** for `<format-name>`, `<format-name>-devkit`, or `<format-name>-sdk`
-2. **Search GitHub** for `<format-name> devkit` or `<format-name> python`
-3. **Search web** for "FiftyOne import <format-name>" or "<format-name> python tutorial"
-4. **Check the dataset's official website** for developer tools/SDK
-5. **Present findings to user** with installation options
-
-**After installation:**
-1. **Verify** the package is installed: `pip show <package-name>`
-2. **Test import** in Python: `python -c "from <package> import ..."`
-3. **Search for FiftyOne integration** examples or write custom import code
+**Additional packages for 3D processing:** `open3d` (PCD conversion), `pyntcloud`, `laspy`
+(LAS/LAZ). **For Hugging Face Hub:** `huggingface_hub`, `pyarrow`, `Pillow`.
 
 ### 5. Confirm before importing
 Present findings to user and **explicitly ask for confirmation** before creating the dataset.
@@ -181,6 +119,13 @@ Classify files by extension:
 | `.mp4`, `.avi`, `.mov`, `.mkv`, `.webm` | Video | `video` |
 | `.pcd`, `.ply`, `.las`, `.laz` | Point Cloud | `point-cloud` |
 | `.fo3d`, `.obj`, `.gltf`, `.glb` | 3D Scene | `3d` |
+| `.mcap`, `.bag`, `.rrd` | Multimodal (robotics/AV sensor log) | `multimodal` |
+
+**MCAP recordings are a special case.** A single `.mcap` file is one self-contained multimodal
+episode that can hold many time-synchronized streams internally (camera images, LIDAR, IMU, GPS,
+transforms, diagnostics), each as its own channel/topic. There is no separate MCAP dataset type and
+no labels file to import: one `.mcap` file is one sample. See
+[Step 9D](#step-9d-import-multimodal-mcap-recordings) below.
 
 ### Step 3: Detect Label Format
 
@@ -201,78 +146,16 @@ Identify label format from file patterns:
 | `.dcm` DICOM files | DICOM | `DICOM` |
 | `.tiff` with geo metadata | GeoTIFF | `GeoTIFF` |
 
-**Specialized Autonomous Driving Formats (require external packages):**
-
-| Directory Pattern | Format | Required Package |
-|------------------|--------|------------------|
-| `camera/`, `lidar/`, `annotations/cuboids/` with `.pkl.gz` | PandaSet | `pandaset-devkit` |
-| `samples/`, `sweeps/`, `v1.0-*` folders | nuScenes | `nuscenes-devkit` |
-| `segment-*` with `.tfrecord` files | Waymo Open | `waymo-open-dataset-tf` |
-| `argoverse-tracking/` structure | Argoverse | `argoverse-api` |
-| `training/`, `testing/` with `calib/`, `velodyne/` | KITTI 3D | `pykitti` |
-| `scenes/`, `aerial_map/` | Lyft L5 | `l5kit` |
+**Specialized autonomous driving formats** (PandaSet, nuScenes, Waymo Open, Argoverse, KITTI 3D,
+Lyft L5, A2D2) need an external devkit and a conversion step. See
+[SPECIALIZED-3D-FORMATS.md](SPECIALIZED-3D-FORMATS.md) for directory-pattern detection, the
+package table, and the complete conversion workflow.
 
 ### Step 4: Detect Required Packages
 
-After identifying the format, check if external packages are needed:
-
-```bash
-# Check if package is installed (use the actual package name, not repo name)
-pip show pandaset
-
-# If not found, the package needs to be installed
-```
-
-**If packages are required:**
-
-1. **Inform user** what packages are needed and why
-
-2. **Search for installation method** if not in the common mappings table:
-   - Search PyPI first: `pip search <package>` or check pypi.org
-   - Search GitHub for the devkit/SDK repository
-   - Check the dataset's official documentation
-   - Search web: "<dataset-name> python install"
-
-3. **Ask for permission** to install:
-   ```
-   This dataset appears to be in PandaSet format, which requires the `pandaset` package.
-
-   The package is not on PyPI and must be installed from GitHub:
-   pip install "git+https://github.com/scaleapi/pandaset-devkit.git#subdirectory=python"
-
-   Would you like me to:
-   - Install the package (recommended)
-   - Search for alternative import methods
-   - Abort and let you install manually
-   ```
-
-4. **Install using the appropriate method**:
-   ```bash
-   # PyPI (if available)
-   pip install <package-name>
-
-   # GitHub URL (if not on PyPI)
-   pip install "git+https://github.com/<org>/<repo>.git#subdirectory=python"
-
-   # Clone and install (for complex builds)
-   git clone https://github.com/<org>/<repo>.git && cd <repo> && pip install .
-   ```
-
-5. **Verify installation**:
-   ```bash
-   pip show <package-name>
-   ```
-
-6. **Test the import** in Python:
-   ```bash
-   python -c "from <package> import <main_class>; print('OK')"
-   ```
-
-7. **Search for FiftyOne integration code**:
-   - Search: "FiftyOne <format-name> import example"
-   - Search: "<format-name> to FiftyOne grouped dataset"
-   - Check FiftyOne docs for similar dataset types
-   - If no examples exist, build custom import code using the devkit API
+Check whether the detected format's package is already installed (`pip show <package>`), inform
+the user what's needed and why, ask permission before installing, then verify with a smoke-test
+import. Full detail in [SPECIALIZED-3D-FORMATS.md](SPECIALIZED-3D-FORMATS.md).
 
 ### Step 5: Detect Grouping Pattern
 
@@ -311,6 +194,18 @@ Detection: Common prefix = group ID, suffix = slice name
 ├── image_003.jpg
 ```
 Detection: Single media type, no clear grouping pattern
+
+**Pattern D: MCAP Multimodal Recordings (No Grouping Needed)**
+```
+/data/
+├── episode-0001.mcap
+├── episode-0002.mcap
+├── episode-0003.mcap
+```
+Detection: Each `.mcap`/`.bag`/`.rrd` file is already a self-contained multimodal recording
+(cameras, LIDAR, IMU, GPS, etc. are internal channels within the file). Do **not** try to group
+these with other files — import each recording as a single sample. See
+[Step 9D](#step-9d-import-multimodal-mcap-recordings).
 
 ### Step 6: Present Findings to User
 
@@ -485,219 +380,129 @@ print(f"Added {len(dataset)} samples in {len(dataset.distinct('group.id'))} grou
 
 ### Step 9C: Import Specialized Format Dataset (3D/Autonomous Driving)
 
-For datasets requiring external packages (PandaSet, nuScenes, etc.), use the devkit to load data and convert to FiftyOne format.
+For datasets requiring an external devkit (PandaSet, nuScenes, Waymo, Argoverse, KITTI 3D, Lyft
+L5, A2D2), use the devkit to load the raw data, convert point clouds to PCD, build `fo.Scene`
+objects for 3D visualization, and import every detected label type (cuboids, segmentation,
+tracking). The full workflow, PCD conversion code, label-type mapping, and a complete worked
+PandaSet example are in [SPECIALIZED-3D-FORMATS.md](SPECIALIZED-3D-FORMATS.md).
 
-**General approach:**
-1. Search FiftyOne documentation or web for the specific import method
-2. Use the devkit to load the raw data
-3. **Convert point clouds to PCD format** (FiftyOne requires `.pcd` files)
-4. **Create `fo.Scene` objects** for 3D visualization with point clouds
-5. Convert to FiftyOne samples with proper grouping
-6. **Import ALL detected labels** (cuboids, segmentation, etc.) found during scan
+### Step 9D: Import Multimodal (MCAP) Recordings
 
-#### Converting Point Clouds to PCD
+MCAP is the container format FiftyOne uses for time-synchronized robotics and autonomous vehicle
+sensor logs (camera images, LIDAR/point clouds, IMU, GPS, coordinate frame transforms,
+diagnostics, and more, all as channels/topics inside one file). Unlike the specialized 3D formats
+above, **no devkit, no label conversion, and no extra Python package are required on the import
+side** — the sample's `filepath` extension alone is enough for FiftyOne to classify it as
+`media_type == "multimodal"`; decoding channel schemas (ROS 1/2, Foxglove, JSON) and rendering the
+tiled viewer happens entirely client-side in the App when the sample is opened.
 
-Many autonomous driving datasets store LiDAR data in proprietary formats (`.pkl.gz`, `.bin`, `.npy`). Convert to PCD for FiftyOne:
+**This section covers the common case: you already have working `.mcap` files and just need them
+in a dataset.** For anything deeper, three linked reference files carry the rest. Read the one that
+matches what's actually happening:
 
-```python
-import numpy as np
-import open3d as o3d
-from pathlib import Path
+| Situation | Read |
+|---|---|
+| A tile isn't rendering, or the App "looks broken" | [MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md). Check its symptom table before assuming a bug: the viewer fails silently by design when a schema isn't decodable, so most reports of "the import isn't working" turn out not to be import bugs at all |
+| Authoring `.mcap` from raw sensor data (ROS bags, Zarr, HDF5, PCD, CSV, image folders) with `foxglove-sdk`, or converting/merging/splitting/patching existing MCAP files | [MCAP-AUTHORING.md](MCAP-AUTHORING.md) |
+| Building the FiftyOne dataset from finished episodes, or about to declare an import done | [MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md) |
 
-def convert_to_pcd(points, output_path):
-    """
-    Convert point cloud array to PCD file.
-
-    Args:
-        points: numpy array of shape (N, 3) or (N, 4) with XYZ or XYZI
-        output_path: path to save .pcd file
-    """
-    pcd = o3d.geometry.PointCloud()
-    pcd.points = o3d.utility.Vector3dVector(points[:, :3])
-
-    # If intensity is available, store as colors (grayscale)
-    if points.shape[1] >= 4:
-        intensity = points[:, 3]
-        intensity_normalized = (intensity - intensity.min()) / (intensity.max() - intensity.min() + 1e-8)
-        colors = np.stack([intensity_normalized] * 3, axis=1)
-        pcd.colors = o3d.utility.Vector3dVector(colors)
-
-    o3d.io.write_point_cloud(str(output_path), pcd)
-    return output_path
-```
-
-**Note:** Install open3d if needed: `pip install open3d`
-
-#### Creating fo.Scene for 3D Visualization
-
-For each LiDAR frame, create an `fo.Scene` that references the PCD file:
+**1. Import.** Each `.mcap` file becomes exactly one sample. No package install step is needed.
+Use the same `MEDIA_ONLY` + glob pattern approach as Use Case 3 (point clouds):
 
 ```python
-import fiftyone as fo
-
-# Create a 3D scene for the point cloud
-scene = fo.Scene()
-
-# Add point cloud to the scene
-scene.add_point_cloud(
-    name="lidar",
-    pcd_path="/path/to/frame.pcd",
-    flag_for_projection=True  # Enable projection to camera views
+execute_operator(
+    operator_uri="@voxel51/utils/create_dataset",
+    params={"name": "robot-teleop-episodes", "persistent": true}
 )
 
-# Create sample with the scene
-sample = fo.Sample(filepath="/path/to/scene.fo3d")  # Or use scene directly
-sample["scene"] = scene
+set_context(dataset_name="robot-teleop-episodes")
+
+execute_operator(
+    operator_uri="@voxel51/io/import_samples",
+    params={
+        "import_type": "MEDIA_ONLY",
+        "style": "GLOB_PATTERN",
+        "glob_patt": {"absolute_path": "/path/to/recordings/*.mcap"}
+    }
+)
 ```
 
-#### Importing ALL Labels Detected During Scan
-
-During the folder scan (Step 1), identify ALL label types present:
-
-```bash
-# Example: List all annotation directories/files
-ls -la /path/to/dataset/annotations/
-# Output might show: cuboids/, semseg/, tracking/, instances.json, etc.
-```
-
-**Map detected labels to FiftyOne label types:**
-
-| Annotation Type | FiftyOne Label Type | Field Name |
-|-----------------|---------------------|------------|
-| 3D Cuboids/Bounding Boxes | `fo.Detection` with 3D attributes | `detections_3d` |
-| Semantic Segmentation | `fo.Segmentation` | `segmentation` |
-| Instance Segmentation | `fo.Detections` with masks | `instances` |
-| Tracking IDs | Add `track_id` to detections | `tracks` |
-| Classification | `fo.Classification` | `classification` |
-| Keypoints/Pose | `fo.Keypoints` | `keypoints` |
-
-**Example: PandaSet Full Import with Labels**
+Or directly in Python, for more control (e.g. tagging episodes by source, adding custom metadata
+fields extracted from the filename):
 
 ```python
 import fiftyone as fo
-import numpy as np
-import open3d as o3d
 from pathlib import Path
-import gzip
-import pickle
 
-data_path = Path("/path/to/pandaset")
-pcd_output_dir = data_path / "pcd_converted"
-pcd_output_dir.mkdir(exist_ok=True)
+dataset = fo.Dataset("robot-teleop-episodes", persistent=True)
 
-# Create dataset with groups
-dataset = fo.Dataset("pandaset", persistent=True)
-dataset.add_group_field("group", default="front_camera")
+recordings_dir = Path("/path/to/recordings")
+samples = [
+    fo.Sample(filepath=str(mcap_file))
+    for mcap_file in sorted(recordings_dir.glob("*.mcap"))
+]
 
-# Get camera names
-camera_names = [d.name for d in (data_path / "camera").iterdir() if d.is_dir()]
-frame_count = len(list((data_path / "camera" / "front_camera").glob("*.jpg")))
-
-# Check what labels exist
-labels_dir = data_path / "annotations"
-available_labels = [d.name for d in labels_dir.iterdir() if d.is_dir()]
-print(f"Found label types: {available_labels}")  # e.g., ['cuboids', 'semseg']
-
-samples = []
-for frame_idx in range(frame_count):
-    frame_id = f"{frame_idx:02d}"
-    group = fo.Group()
-
-    # === Add camera images ===
-    for cam_name in camera_names:
-        img_path = data_path / "camera" / cam_name / f"{frame_id}.jpg"
-        if img_path.exists():
-            sample = fo.Sample(filepath=str(img_path))
-            sample["group"] = group.element(cam_name)
-            sample["frame_idx"] = frame_idx
-            samples.append(sample)
-
-    # === Convert and add LiDAR point cloud ===
-    lidar_pkl = data_path / "lidar" / f"{frame_id}.pkl.gz"
-    if lidar_pkl.exists():
-        # Load pickle
-        with gzip.open(lidar_pkl, 'rb') as f:
-            lidar_data = pickle.load(f)
-
-        # Extract points (adjust based on actual data structure)
-        if isinstance(lidar_data, dict):
-            points = lidar_data.get('points', lidar_data.get('data'))
-        else:
-            points = np.array(lidar_data)
-
-        # Convert to PCD
-        pcd_path = pcd_output_dir / f"{frame_id}.pcd"
-        pcd = o3d.geometry.PointCloud()
-        pcd.points = o3d.utility.Vector3dVector(points[:, :3])
-        o3d.io.write_point_cloud(str(pcd_path), pcd)
-
-        # Create 3D sample with scene
-        lidar_sample = fo.Sample(filepath=str(pcd_path))
-        lidar_sample["group"] = group.element("lidar")
-        lidar_sample["frame_idx"] = frame_idx
-
-        # === Load 3D cuboid labels if available ===
-        # IMPORTANT: Store 3D attributes as flat scalar fields, NOT lists
-        # Using lists (e.g., location=[x,y,z]) causes "Symbol.iterator" errors in 3D viewer
-        if "cuboids" in available_labels:
-            cuboids_pkl = labels_dir / "cuboids" / f"{frame_id}.pkl.gz"
-            if cuboids_pkl.exists():
-                with gzip.open(cuboids_pkl, 'rb') as f:
-                    cuboids_df = pickle.load(f)  # PandaSet uses pandas DataFrame
-
-                detections = []
-                for _, row in cuboids_df.iterrows():
-                    detection = fo.Detection(
-                        label=row.get("label", "object"),
-                        bounding_box=[0, 0, 0.01, 0.01],  # minimal 2D placeholder
-                    )
-                    # Store 3D attributes as FLAT SCALAR fields (not lists!)
-                    detection["pos_x"] = float(row.get("position.x", 0))
-                    detection["pos_y"] = float(row.get("position.y", 0))
-                    detection["pos_z"] = float(row.get("position.z", 0))
-                    detection["dim_x"] = float(row.get("dimensions.x", 1))
-                    detection["dim_y"] = float(row.get("dimensions.y", 1))
-                    detection["dim_z"] = float(row.get("dimensions.z", 1))
-                    detection["yaw"] = float(row.get("yaw", 0))
-                    detection["track_id"] = str(row.get("uuid", ""))
-                    detection["stationary"] = bool(row.get("stationary", False))
-                    detections.append(detection)
-
-                lidar_sample["ground_truth"] = fo.Detections(detections=detections)
-
-        # === Load semantic segmentation if available ===
-        if "semseg" in available_labels:
-            semseg_pkl = labels_dir / "semseg" / f"{frame_id}.pkl.gz"
-            if semseg_pkl.exists():
-                with gzip.open(semseg_pkl, 'rb') as f:
-                    semseg_data = pickle.load(f)
-                # Store as custom field (point-wise labels)
-                lidar_sample["point_labels"] = semseg_data.tolist() if hasattr(semseg_data, 'tolist') else semseg_data
-
-        samples.append(lidar_sample)
-
-# Add all samples
 dataset.add_samples(samples)
-dataset.save()
 
-print(f"Imported {len(dataset)} groups with {len(dataset.select_group_slices())} total samples")
-print(f"Slices: {dataset.group_slices}")
-print(f"Labels imported: {available_labels}")
+print(dataset.media_type)  # "multimodal"
 ```
 
-**Dynamic Import Discovery:**
-If no example exists for the format:
-1. Search: "FiftyOne <format-name> import example"
-2. Search: "<format-name> devkit python example"
-3. Read the devkit documentation to understand data structure
-4. Explore the annotation files to understand label format:
-   ```python
-   import pickle, gzip
-   with gzip.open("annotations/cuboids/00.pkl.gz", "rb") as f:
-       data = pickle.load(f)
-   print(type(data), data[0] if isinstance(data, list) else data)
-   ```
-5. Build custom import code based on the devkit API and label structure
+**2. Do not group MCAP samples with other slices.** Each `.mcap` file already carries all of its
+sensor streams internally. Adding it as one slice in a `fo.Group()` alongside separately exported
+camera or LiDAR files would duplicate data that's already inside the recording.
+
+**2b. Detect capabilities by schema, not by topic name, and store them as fields.** A topic's name
+is not a reliable signal for what it renders as. A topic named `/livox/lidar` or
+`/os_node/imu_packets` looks like LiDAR or IMU data, but if its actual message schema is a
+vendor-specific format (Livox's `livox_ros_driver/msg/CustomMsg`, or Ouster's raw
+`ouster_ros/msg/PacketMsg`), FiftyOne has no built-in decoder for it. It will never render in the
+3D or Plot tile no matter how the topic is named, and always falls back to the raw Message tile.
+Only a fixed set of schemas render in each tile type. See
+[MCAP-TROUBLESHOOTING.md's schema-to-tile table](MCAP-TROUBLESHOOTING.md#schema-to-tile-reference)
+for the full list; a custom or proprietary LiDAR message is not on it and is expected to stay in
+the Message tile.
+
+Check real schemas from the file with the lightweight `mcap` package (`pip install mcap`, a small
+pure-Python reader unrelated to any ROS install) and store the result as boolean fields
+(`has_pointcloud`, `has_image`, `has_gps`, `has_imu`, and so on) so users and agents can query
+capability across many recordings without opening each one in the App. Use the full
+`mcap_stats()`/`build_sample()` helper in
+[MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#capability-flags-from-schemas-not-topic-names)
+rather than reimplementing a narrower version. It also captures `duration_s`, `message_count`,
+`topics`, and `schemas` needed for validation in the same pass, and answers "will this file show a
+point cloud" with `dataset.match(F("has_pointcloud"))` instead of opening every sample to find out.
+
+**3. Validate.** Confirm `dataset.media_type == "multimodal"` and that the sample count matches the
+number of recording files found during the scan. Individual channels, topics, annotations, and time
+tracks are inspected in the App's multimodal viewer, not via the Python import step. For anything
+beyond a handful of files, also run the cheap `validate_mcap()` structural check in
+[MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#a-written-file-is-not-a-good-file).
+A file can pass every count-based check here while being silently corrupted in a way that only
+surfaces when a sample is actually opened.
+
+**4. Launch the App** to explore streams. FiftyOne opens multimodal samples in a tiled viewer
+(image, 3D, map, plot, message, and log tiles) with a shared playback clock:
+
+```python
+launch_app(dataset_name="robot-teleop-episodes")
+```
+
+**Note on "no data" at the start of playback:** the Message, Plot, 3D, and Map tiles all show the
+most recent message as of the current playhead. If a topic's first message doesn't start at `t=0`
+(common, since sensors have startup lag), a tile bound to it will legitimately show nothing, for
+example "No message at or before the playhead on this topic," until playback is scrubbed or played
+past that topic's first timestamp. This is expected behavior, not a broken import. Verify by
+pressing play or scrubbing forward before concluding a tile is broken. If a tile still looks wrong
+after that, check [MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md)'s symptom table before
+assuming the import failed.
+
+**Note:** temporal tags (tags on a time interval within a recording, added with
+`dataset.temporal_tags.add(...)`) work locally with no Enterprise requirement. See
+[MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md#temporal-tags) for the pattern.
+MCAP indexing, which projects channels into queryable Parquet tables for cross-recording search, is
+an Enterprise-only feature and out of scope for a local import. See the
+[FiftyOne Multimodal guide](https://docs.voxel51.com/user_guide/multimodal.html) if a user asks
+about it.
 
 ### Step 10: Import Additional Labels (Optional)
 
@@ -750,6 +555,7 @@ launch_app(dataset_name="my-dataset")
 | `video` | `.mp4`, `.avi`, `.mov`, `.mkv`, `.webm` | Video files with frames |
 | `point-cloud` | `.pcd`, `.ply`, `.las`, `.laz` | 3D point cloud data |
 | `3d` | `.fo3d`, `.obj`, `.gltf`, `.glb` | 3D scenes and meshes |
+| `multimodal` | `.mcap`, `.bag`, `.rrd` | Time-synchronized robotics/AV sensor recordings (MCAP container format) |
 
 ### Label Formats
 
@@ -777,202 +583,8 @@ launch_app(dataset_name="my-dataset")
 
 ## Common Use Cases
 
-### Use Case 1: Simple Image Dataset with COCO Labels
-
-```python
-# Scan directory
-# Found: 5000 images, annotations.json (COCO format)
-
-execute_operator(
-    operator_uri="@voxel51/utils/create_dataset",
-    params={"name": "coco-dataset", "persistent": true}
-)
-
-set_context(dataset_name="coco-dataset")
-
-execute_operator(
-    operator_uri="@voxel51/io/import_samples",
-    params={
-        "import_type": "MEDIA_AND_LABELS",
-        "dataset_type": "COCO",
-        "data_path": {"absolute_path": "/path/to/images"},
-        "labels_path": {"absolute_path": "/path/to/annotations.json"},
-        "label_field": "ground_truth"
-    }
-)
-
-launch_app(dataset_name="coco-dataset")
-```
-
-### Use Case 2: YOLO Dataset
-
-```python
-# Scan directory
-# Found: data.yaml, images/, labels/ (YOLOv5 format)
-
-execute_operator(
-    operator_uri="@voxel51/utils/create_dataset",
-    params={"name": "yolo-dataset", "persistent": true}
-)
-
-set_context(dataset_name="yolo-dataset")
-
-execute_operator(
-    operator_uri="@voxel51/io/import_samples",
-    params={
-        "import_type": "MEDIA_AND_LABELS",
-        "dataset_type": "YOLOv5",
-        "dataset_dir": {"absolute_path": "/path/to/yolo/dataset"},
-        "label_field": "ground_truth"
-    }
-)
-
-launch_app(dataset_name="yolo-dataset")
-```
-
-### Use Case 3: Point Cloud Dataset
-
-```python
-# Scan directory
-# Found: 1000 .pcd files, labels/ with KITTI format
-
-execute_operator(
-    operator_uri="@voxel51/utils/create_dataset",
-    params={"name": "lidar-dataset", "persistent": true}
-)
-
-set_context(dataset_name="lidar-dataset")
-
-# Import point clouds
-execute_operator(
-    operator_uri="@voxel51/io/import_samples",
-    params={
-        "import_type": "MEDIA_ONLY",
-        "style": "GLOB_PATTERN",
-        "glob_patt": {"absolute_path": "/path/to/data/*.pcd"}
-    }
-)
-
-launch_app(dataset_name="lidar-dataset")
-```
-
-### Use Case 4: Autonomous Driving (Multimodal Groups)
-
-This is the most complex case - multiple cameras + LiDAR per scene:
-
-```python
-import fiftyone as fo
-from pathlib import Path
-
-# Create dataset with group support
-dataset = fo.Dataset("driving-dataset", persistent=True)
-dataset.add_group_field("group", default="front_camera")
-
-data_dir = Path("/path/to/driving_data")
-samples = []
-
-# Process each scene folder
-for scene_dir in sorted(data_dir.iterdir()):
-    if not scene_dir.is_dir():
-        continue
-
-    group = fo.Group()
-
-    # Map files to slices
-    slice_mapping = {
-        "front": "front_camera",
-        "left": "left_camera",
-        "right": "right_camera",
-        "rear": "rear_camera",
-        "lidar": "lidar",
-        "radar": "radar"
-    }
-
-    for file in scene_dir.iterdir():
-        # Determine slice from filename
-        for key, slice_name in slice_mapping.items():
-            if key in file.stem.lower():
-                samples.append(fo.Sample(
-                    filepath=str(file),
-                    group=group.element(slice_name)
-                ))
-                break
-
-dataset.add_samples(samples)
-dataset.save()
-
-print(f"Created {len(dataset.distinct('group.id'))} groups")
-print(f"Slices: {dataset.group_slices}")
-print(f"Media types: {dataset.group_media_types}")
-
-# Launch app
-session = fo.launch_app(dataset)
-```
-
-### Use Case 5: Classification Directory Tree
-
-```python
-# Scan directory
-# Found: cats/, dogs/, birds/ folders with images inside
-
-execute_operator(
-    operator_uri="@voxel51/utils/create_dataset",
-    params={"name": "classification-dataset", "persistent": true}
-)
-
-set_context(dataset_name="classification-dataset")
-
-execute_operator(
-    operator_uri="@voxel51/io/import_samples",
-    params={
-        "import_type": "MEDIA_AND_LABELS",
-        "dataset_type": "Image Classification Directory Tree",
-        "dataset_dir": {"absolute_path": "/path/to/classification"},
-        "label_field": "ground_truth"
-    }
-)
-
-launch_app(dataset_name="classification-dataset")
-```
-
-### Use Case 6: Mixed Media (Images + Videos)
-
-```python
-# Scan directory
-# Found: images/, videos/ folders
-
-# Create dataset
-execute_operator(
-    operator_uri="@voxel51/utils/create_dataset",
-    params={"name": "mixed-media", "persistent": true}
-)
-
-set_context(dataset_name="mixed-media")
-
-# Import images
-execute_operator(
-    operator_uri="@voxel51/io/import_samples",
-    params={
-        "import_type": "MEDIA_ONLY",
-        "style": "DIRECTORY",
-        "directory": {"absolute_path": "/path/to/images"},
-        "tags": ["image"]
-    }
-)
-
-# Import videos
-execute_operator(
-    operator_uri="@voxel51/io/import_samples",
-    params={
-        "import_type": "MEDIA_ONLY",
-        "style": "DIRECTORY",
-        "directory": {"absolute_path": "/path/to/videos"},
-        "tags": ["video"]
-    }
-)
-
-launch_app(dataset_name="mixed-media")
-```
+Copy-paste starting points for COCO, YOLO, point clouds, autonomous driving groups, classification
+trees, and mixed media are in [USE-CASE-EXAMPLES.md](USE-CASE-EXAMPLES.md).
 
 ## Working with Groups
 
@@ -1070,6 +682,19 @@ dataset = load_from_hub(
 - Check FiftyOne 3D visualization is enabled
 - Verify point cloud plugin is installed
 
+**MCAP sample added but `dataset.media_type` isn't `"multimodal"`**
+- Confirm the filepath extension is exactly `.mcap`, `.bag`, or `.rrd` (lowercase)
+- A dataset's media type reflects the extensions of *all* its samples — mixing `.mcap` files with
+  images/videos in the same (non-grouped) dataset will raise a media type conflict; keep MCAP
+  recordings in their own dataset or group slice
+
+**A multimodal tile (Image/3D/Map/Plot/Logs) isn't rendering what you expect**
+- This is almost never a broken import — the viewer fails silently by design when a schema isn't
+  decodable or a topic's data doesn't start at `t=0`. Check
+  [MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md)'s symptom table first
+- If you're authoring, converting, or patching the `.mcap` files themselves (not just importing
+  existing ones), see [MCAP-AUTHORING.md](MCAP-AUTHORING.md) instead
+
 **Groups not detected**
 - Check folder structure matches expected patterns
 - Verify consistent naming across scenes
@@ -1105,8 +730,20 @@ dataset = load_from_hub(
 - [FiftyOne Dataset Import Guide](https://docs.voxel51.com/user_guide/dataset_creation/index.html)
 - [Grouped Datasets Guide](https://docs.voxel51.com/user_guide/groups.html)
 - [Point Cloud Support](https://docs.voxel51.com/user_guide/3d.html)
+- [FiftyOne Multimodal (MCAP) Guide](https://docs.voxel51.com/user_guide/multimodal.html)
 - [Supported Dataset Formats](https://docs.voxel51.com/user_guide/dataset_creation/datasets.html)
 - [FiftyOne I/O Plugin](https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/io)
 - [FiftyOne Hugging Face Integration](https://docs.voxel51.com/integrations/huggingface.html)
 - [Hugging Face Hub Documentation](https://huggingface.co/docs/hub/index)
+
+This skill directory ships reference files read on demand rather than every invocation:
+
+- [HF-HUB-IMPORT.md](HF-HUB-IMPORT.md): Hugging Face Hub specifics
+- [SPECIALIZED-3D-FORMATS.md](SPECIALIZED-3D-FORMATS.md): PandaSet/nuScenes/Waymo/Argoverse/KITTI
+  3D/Lyft L5/A2D2 devkit workflow
+- [USE-CASE-EXAMPLES.md](USE-CASE-EXAMPLES.md): copy-paste starting points for common import shapes
+- [MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md): symptom table and why a tile isn't rendering
+- [MCAP-AUTHORING.md](MCAP-AUTHORING.md): authoring MCAP from raw data, converting ROS bags, merging/patching
+- [MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md): capability flags, validation,
+  process discipline for MCAP imports
 

--- a/skills/fiftyone-dataset-import/SPECIALIZED-3D-FORMATS.md
+++ b/skills/fiftyone-dataset-import/SPECIALIZED-3D-FORMATS.md
@@ -1,0 +1,215 @@
+# Specialized 3D and autonomous driving formats
+
+Read this when a scan turns up a named autonomous-driving devkit format (PandaSet, nuScenes, Waymo
+Open, Argoverse, KITTI 3D, Lyft L5, A2D2) rather than a plain point-cloud or image directory. These
+formats need an external devkit to parse, plus a conversion step into FiftyOne's own 3D
+representation. For MCAP robotics/AV recordings specifically, see
+[MCAP-AUTHORING.md](MCAP-AUTHORING.md), [MCAP-TROUBLESHOOTING.md](MCAP-TROUBLESHOOTING.md), and
+[MCAP-DATASET-AND-VALIDATION.md](MCAP-DATASET-AND-VALIDATION.md) instead.
+
+## Contents
+
+1. [Directory pattern detection](#directory-pattern-detection)
+2. [Required packages](#required-packages)
+3. [Converting point clouds to PCD](#converting-point-clouds-to-pcd)
+4. [Creating fo.Scene for 3D visualization](#creating-foscene-for-3d-visualization)
+5. [Mapping labels to FiftyOne types](#mapping-labels-to-fiftyone-types)
+6. [Complete example: PandaSet with all labels](#complete-example-pandaset-with-all-labels)
+7. [No example exists for this format](#no-example-exists-for-this-format)
+
+## Directory pattern detection
+
+| Directory pattern | Format | Required package |
+|---|---|---|
+| `camera/`, `lidar/`, `annotations/cuboids/` with `.pkl.gz` | PandaSet | `pandaset-devkit` |
+| `samples/`, `sweeps/`, `v1.0-*` folders | nuScenes | `nuscenes-devkit` |
+| `segment-*` with `.tfrecord` files | Waymo Open | `waymo-open-dataset-tf` |
+| `argoverse-tracking/` structure | Argoverse | `argoverse-api` |
+| `training/`, `testing/` with `calib/`, `velodyne/` | KITTI 3D | `pykitti` |
+| `scenes/`, `aerial_map/` | Lyft L5 | `l5kit` |
+
+## Required packages
+
+| Format | Package | Install |
+|---|---|---|
+| PandaSet | `pandaset` | `pip install "git+https://github.com/scaleapi/pandaset-devkit.git#subdirectory=python"` |
+| nuScenes | `nuscenes-devkit` | `pip install nuscenes-devkit` |
+| Waymo Open | `waymo-open-dataset-tf` | See Waymo docs (requires TensorFlow) |
+| Argoverse 2 | `av2` | `pip install av2` |
+| KITTI 3D | `pykitti` | `pip install pykitti` |
+| Lyft L5 | `l5kit` | `pip install l5kit` |
+| A2D2 | `a2d2` | See Audi A2D2 docs |
+
+Check whether the package is already installed (`pip show <package>`), then ask the user for
+permission before installing. If the package isn't on PyPI, install from GitHub, with a
+subdirectory flag for monorepos (`pip install "git+https://github.com/<org>/<repo>.git#subdirectory=python"`).
+After installing, verify with `pip show <package>` and a smoke-test import.
+
+If the format isn't in the table above, search PyPI and GitHub for `<format-name>-devkit` or
+`<format-name>-sdk`, check the dataset's official site for developer tools, and search "FiftyOne
+import `<format-name>`" before writing custom code.
+
+## Converting point clouds to PCD
+
+Autonomous driving datasets store LiDAR data in proprietary formats (`.pkl.gz`, `.bin`, `.npy`).
+FiftyOne requires `.pcd` files, so convert first (`pip install open3d` if needed):
+
+```python
+import numpy as np
+import open3d as o3d
+from pathlib import Path
+
+def convert_to_pcd(points, output_path):
+    """points: (N, 3) or (N, 4) array with XYZ or XYZI. Writes a .pcd file."""
+    pcd = o3d.geometry.PointCloud()
+    pcd.points = o3d.utility.Vector3dVector(points[:, :3])
+
+    if points.shape[1] >= 4:
+        intensity = points[:, 3]
+        intensity_normalized = (intensity - intensity.min()) / (intensity.max() - intensity.min() + 1e-8)
+        colors = np.stack([intensity_normalized] * 3, axis=1)
+        pcd.colors = o3d.utility.Vector3dVector(colors)
+
+    o3d.io.write_point_cloud(str(output_path), pcd)
+    return output_path
+```
+
+## Creating fo.Scene for 3D visualization
+
+For each LiDAR frame, create an `fo.Scene` that references the PCD file:
+
+```python
+import fiftyone as fo
+
+scene = fo.Scene()
+scene.add_point_cloud(
+    name="lidar",
+    pcd_path="/path/to/frame.pcd",
+    flag_for_projection=True,  # enables projection to camera views
+)
+
+sample = fo.Sample(filepath="/path/to/scene.fo3d")
+sample["scene"] = scene
+```
+
+## Mapping labels to FiftyOne types
+
+| Annotation type | FiftyOne label type | Field name |
+|---|---|---|
+| 3D cuboids/bounding boxes | `fo.Detection` with 3D attributes | `detections_3d` |
+| Semantic segmentation | `fo.Segmentation` | `segmentation` |
+| Instance segmentation | `fo.Detections` with masks | `instances` |
+| Tracking IDs | `track_id` added to detections | `tracks` |
+| Classification | `fo.Classification` | `classification` |
+| Keypoints/pose | `fo.Keypoints` | `keypoints` |
+
+## Complete example: PandaSet with all labels
+
+```python
+import fiftyone as fo
+import numpy as np
+import open3d as o3d
+from pathlib import Path
+import gzip
+import pickle
+
+data_path = Path("/path/to/pandaset")
+pcd_output_dir = data_path / "pcd_converted"
+pcd_output_dir.mkdir(exist_ok=True)
+
+dataset = fo.Dataset("pandaset", persistent=True)
+dataset.add_group_field("group", default="front_camera")
+
+camera_names = [d.name for d in (data_path / "camera").iterdir() if d.is_dir()]
+frame_count = len(list((data_path / "camera" / "front_camera").glob("*.jpg")))
+
+labels_dir = data_path / "annotations"
+available_labels = [d.name for d in labels_dir.iterdir() if d.is_dir()]
+print(f"Found label types: {available_labels}")  # e.g., ['cuboids', 'semseg']
+
+samples = []
+for frame_idx in range(frame_count):
+    frame_id = f"{frame_idx:02d}"
+    group = fo.Group()
+
+    for cam_name in camera_names:
+        img_path = data_path / "camera" / cam_name / f"{frame_id}.jpg"
+        if img_path.exists():
+            sample = fo.Sample(filepath=str(img_path))
+            sample["group"] = group.element(cam_name)
+            sample["frame_idx"] = frame_idx
+            samples.append(sample)
+
+    lidar_pkl = data_path / "lidar" / f"{frame_id}.pkl.gz"
+    if lidar_pkl.exists():
+        with gzip.open(lidar_pkl, "rb") as f:
+            lidar_data = pickle.load(f)
+
+        points = lidar_data.get("points", lidar_data.get("data")) if isinstance(lidar_data, dict) \
+            else np.array(lidar_data)
+
+        pcd_path = pcd_output_dir / f"{frame_id}.pcd"
+        pcd = o3d.geometry.PointCloud()
+        pcd.points = o3d.utility.Vector3dVector(points[:, :3])
+        o3d.io.write_point_cloud(str(pcd_path), pcd)
+
+        lidar_sample = fo.Sample(filepath=str(pcd_path))
+        lidar_sample["group"] = group.element("lidar")
+        lidar_sample["frame_idx"] = frame_idx
+
+        # Store 3D attributes as flat scalar fields, not lists. A list (e.g.
+        # location=[x, y, z]) causes "Symbol.iterator" errors in the 3D viewer.
+        if "cuboids" in available_labels:
+            cuboids_pkl = labels_dir / "cuboids" / f"{frame_id}.pkl.gz"
+            if cuboids_pkl.exists():
+                with gzip.open(cuboids_pkl, "rb") as f:
+                    cuboids_df = pickle.load(f)  # PandaSet uses a pandas DataFrame
+
+                detections = []
+                for _, row in cuboids_df.iterrows():
+                    detection = fo.Detection(
+                        label=row.get("label", "object"),
+                        bounding_box=[0, 0, 0.01, 0.01],  # minimal 2D placeholder
+                    )
+                    detection["pos_x"] = float(row.get("position.x", 0))
+                    detection["pos_y"] = float(row.get("position.y", 0))
+                    detection["pos_z"] = float(row.get("position.z", 0))
+                    detection["dim_x"] = float(row.get("dimensions.x", 1))
+                    detection["dim_y"] = float(row.get("dimensions.y", 1))
+                    detection["dim_z"] = float(row.get("dimensions.z", 1))
+                    detection["yaw"] = float(row.get("yaw", 0))
+                    detection["track_id"] = str(row.get("uuid", ""))
+                    detection["stationary"] = bool(row.get("stationary", False))
+                    detections.append(detection)
+
+                lidar_sample["ground_truth"] = fo.Detections(detections=detections)
+
+        if "semseg" in available_labels:
+            semseg_pkl = labels_dir / "semseg" / f"{frame_id}.pkl.gz"
+            if semseg_pkl.exists():
+                with gzip.open(semseg_pkl, "rb") as f:
+                    semseg_data = pickle.load(f)
+                lidar_sample["point_labels"] = semseg_data.tolist() if hasattr(semseg_data, "tolist") else semseg_data
+
+        samples.append(lidar_sample)
+
+dataset.add_samples(samples)
+dataset.save()
+
+print(f"Imported {len(dataset)} groups with {len(dataset.select_group_slices())} total samples")
+print(f"Slices: {dataset.group_slices}")
+print(f"Labels imported: {available_labels}")
+```
+
+## No example exists for this format
+
+1. Search "FiftyOne `<format-name>` import example" and "`<format-name>` devkit python example".
+2. Read the devkit documentation to understand the data structure.
+3. Explore an annotation file directly:
+   ```python
+   import pickle, gzip
+   with gzip.open("annotations/cuboids/00.pkl.gz", "rb") as f:
+       data = pickle.load(f)
+   print(type(data), data[0] if isinstance(data, list) else data)
+   ```
+4. Build custom import code from the devkit API and the label structure you found.

--- a/skills/fiftyone-dataset-import/USE-CASE-EXAMPLES.md
+++ b/skills/fiftyone-dataset-import/USE-CASE-EXAMPLES.md
@@ -1,0 +1,195 @@
+# Use case examples
+
+Copy-paste starting points for common import shapes. Each assumes the scan and format detection
+in `SKILL.md` steps 1 to 7 are already done and the user confirmed. For MCAP recordings, see
+[SKILL.md's Step 9D](SKILL.md#step-9d-import-multimodal-mcap-recordings). For PandaSet/nuScenes/
+Waymo/Argoverse/KITTI 3D/Lyft L5/A2D2, see [SPECIALIZED-3D-FORMATS.md](SPECIALIZED-3D-FORMATS.md).
+
+## Contents
+
+1. [Simple image dataset with COCO labels](#1-simple-image-dataset-with-coco-labels)
+2. [YOLO dataset](#2-yolo-dataset)
+3. [Point cloud dataset](#3-point-cloud-dataset)
+4. [Autonomous driving, multimodal groups](#4-autonomous-driving-multimodal-groups)
+5. [Classification directory tree](#5-classification-directory-tree)
+6. [Mixed media, images and videos](#6-mixed-media-images-and-videos)
+
+## 1. Simple image dataset with COCO labels
+
+```python
+# Found: 5000 images, annotations.json (COCO format)
+
+execute_operator(
+    operator_uri="@voxel51/utils/create_dataset",
+    params={"name": "coco-dataset", "persistent": true}
+)
+
+set_context(dataset_name="coco-dataset")
+
+execute_operator(
+    operator_uri="@voxel51/io/import_samples",
+    params={
+        "import_type": "MEDIA_AND_LABELS",
+        "dataset_type": "COCO",
+        "data_path": {"absolute_path": "/path/to/images"},
+        "labels_path": {"absolute_path": "/path/to/annotations.json"},
+        "label_field": "ground_truth"
+    }
+)
+
+launch_app(dataset_name="coco-dataset")
+```
+
+## 2. YOLO dataset
+
+```python
+# Found: data.yaml, images/, labels/ (YOLOv5 format)
+
+execute_operator(
+    operator_uri="@voxel51/utils/create_dataset",
+    params={"name": "yolo-dataset", "persistent": true}
+)
+
+set_context(dataset_name="yolo-dataset")
+
+execute_operator(
+    operator_uri="@voxel51/io/import_samples",
+    params={
+        "import_type": "MEDIA_AND_LABELS",
+        "dataset_type": "YOLOv5",
+        "dataset_dir": {"absolute_path": "/path/to/yolo/dataset"},
+        "label_field": "ground_truth"
+    }
+)
+
+launch_app(dataset_name="yolo-dataset")
+```
+
+## 3. Point cloud dataset
+
+```python
+# Found: 1000 .pcd files, labels/ with KITTI format
+
+execute_operator(
+    operator_uri="@voxel51/utils/create_dataset",
+    params={"name": "lidar-dataset", "persistent": true}
+)
+
+set_context(dataset_name="lidar-dataset")
+
+execute_operator(
+    operator_uri="@voxel51/io/import_samples",
+    params={
+        "import_type": "MEDIA_ONLY",
+        "style": "GLOB_PATTERN",
+        "glob_patt": {"absolute_path": "/path/to/data/*.pcd"}
+    }
+)
+
+launch_app(dataset_name="lidar-dataset")
+```
+
+## 4. Autonomous driving, multimodal groups
+
+Multiple cameras plus LiDAR per scene, so this goes through Python directly rather than an
+operator call:
+
+```python
+import fiftyone as fo
+from pathlib import Path
+
+dataset = fo.Dataset("driving-dataset", persistent=True)
+dataset.add_group_field("group", default="front_camera")
+
+data_dir = Path("/path/to/driving_data")
+samples = []
+
+slice_mapping = {
+    "front": "front_camera",
+    "left": "left_camera",
+    "right": "right_camera",
+    "rear": "rear_camera",
+    "lidar": "lidar",
+    "radar": "radar",
+}
+
+for scene_dir in sorted(data_dir.iterdir()):
+    if not scene_dir.is_dir():
+        continue
+
+    group = fo.Group()
+    for file in scene_dir.iterdir():
+        for key, slice_name in slice_mapping.items():
+            if key in file.stem.lower():
+                samples.append(fo.Sample(filepath=str(file), group=group.element(slice_name)))
+                break
+
+dataset.add_samples(samples)
+dataset.save()
+
+print(f"Created {len(dataset.distinct('group.id'))} groups")
+print(f"Slices: {dataset.group_slices}")
+print(f"Media types: {dataset.group_media_types}")
+
+session = fo.launch_app(dataset)
+```
+
+## 5. Classification directory tree
+
+```python
+# Found: cats/, dogs/, birds/ folders with images inside
+
+execute_operator(
+    operator_uri="@voxel51/utils/create_dataset",
+    params={"name": "classification-dataset", "persistent": true}
+)
+
+set_context(dataset_name="classification-dataset")
+
+execute_operator(
+    operator_uri="@voxel51/io/import_samples",
+    params={
+        "import_type": "MEDIA_AND_LABELS",
+        "dataset_type": "Image Classification Directory Tree",
+        "dataset_dir": {"absolute_path": "/path/to/classification"},
+        "label_field": "ground_truth"
+    }
+)
+
+launch_app(dataset_name="classification-dataset")
+```
+
+## 6. Mixed media, images and videos
+
+```python
+# Found: images/, videos/ folders
+
+execute_operator(
+    operator_uri="@voxel51/utils/create_dataset",
+    params={"name": "mixed-media", "persistent": true}
+)
+
+set_context(dataset_name="mixed-media")
+
+execute_operator(
+    operator_uri="@voxel51/io/import_samples",
+    params={
+        "import_type": "MEDIA_ONLY",
+        "style": "DIRECTORY",
+        "directory": {"absolute_path": "/path/to/images"},
+        "tags": ["image"]
+    }
+)
+
+execute_operator(
+    operator_uri="@voxel51/io/import_samples",
+    params={
+        "import_type": "MEDIA_ONLY",
+        "style": "DIRECTORY",
+        "directory": {"absolute_path": "/path/to/videos"},
+        "tags": ["video"]
+    }
+)
+
+launch_app(dataset_name="mixed-media")
+```


### PR DESCRIPTION
## Related Issues

No related issues to link.

## What does this PR do?

Adds native MCAP support to the `fiftyone-dataset-import` skill, allowing robotics and AV sensor recordings (`.mcap`, `.bag`, `.rrd`) to be imported and validated like other supported formats.

Thanks to @harpreetsahota204 for the original MCAP troubleshooting guide, which served as the foundation for this new import workflow.

### What changed

* Adds an MCAP import workflow to `SKILL.md`
* Adds `MCAP-TROUBLESHOOTING.md` for common issues and visualization problems
* Adds `MCAP-AUTHORING.md` for creating, converting, merging, and patching MCAP files
* Adds `MCAP-DATASET-AND-VALIDATION.md` for schema detection and import validation
* Updates `README.md`, `AGENTS.md`, and `commands/help.md` with MCAP support

## Type of Change

* [ ] New skill
* [x] Skill improvement (bug fix, better instructions, edge cases)
* [ ] New agent integration
* [x] Documentation / repo infrastructure
* [ ] Other

## Skill Checklist

* [x] `SKILL.md` has YAML frontmatter with, `name` and `description` at least and all keys are universally valid
* [x] Key Directives section is present (ALWAYS/NEVER rules)
* [x] Complete Workflow section with code examples at each step
* [x] Troubleshooting section covers common failure modes
* [x] `AGENTS.md` updated with the skill entry
* [ ] Tested end-to-end with at least one AI assistant
* [ ] `node scripts/validate-template.mjs` passes
